### PR TITLE
ci: Add repository input for chatops workflows

### DIFF
--- a/.github/workflows/apply-command.yml
+++ b/.github/workflows/apply-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:
@@ -49,5 +53,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       terratest_action: Apply
       apply_timeout: 60

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -34,6 +34,20 @@ jobs:
             })
             console.log(pr.data.head.ref)
             return pr.data.head.ref
+
+      - name: get PR source repository
+        uses: actions/github-script@v6
+        id: src-repo
+        with:
+          result-encoding: string
+          script: |
+            let pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            })
+            console.log(pr.data.head.repo.full_name)
+            return pr.data.head.repo.full_name    
       
       - name: Generate GitHub token
         id: generate-token
@@ -64,6 +78,7 @@ jobs:
             pr-id=${{ github.event.issue.number }}
             pr-title=${{ github.event.issue.title }}
             branch=${{ steps.pr.outputs.result }}
+            repository=${{ steps.src-repo.outputs.result }}
 
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -20,6 +20,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false        
 
 jobs:
   help:

--- a/.github/workflows/idempotence-command.yml
+++ b/.github/workflows/idempotence-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:
@@ -49,5 +53,6 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       terratest_action: Idempotence
       apply_timeout: 60

--- a/.github/workflows/plan-command.yml
+++ b/.github/workflows/plan-command.yml
@@ -32,6 +32,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:
@@ -49,4 +53,5 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       terratest_action: Plan

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -23,6 +23,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   init:
@@ -58,6 +62,7 @@ jobs:
     with:
       pre-commit-hooks: terraform_fmt terraform_docs terraform_tflint checkov
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
 
   finish_comment_pr:
     name: Add a comment to originating PR

--- a/.github/workflows/validate-command.yml
+++ b/.github/workflows/validate-command.yml
@@ -30,6 +30,10 @@ on:
         description: Branch on which the tests should run
         type: string
         default: main
+      repository:
+        description: Repository on which the tests should run
+        type: string
+        required: false
 
 jobs:
   test:
@@ -50,4 +54,5 @@ jobs:
       pr-id: ${{ inputs.pr-id }}
       comment-id: ${{ inputs.comment-id }}
       branch: ${{ inputs.branch }}
+      repository: ${{ inputs.repository }}
       terratest_action: Validate


### PR DESCRIPTION
## Description

Add repository name as input for chatops workflows.

## Motivation and Context

Allow to run the workflows on PRs created from a fork.

## How Has This Been Tested?

Change is based on https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/pull/376

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
