### PR TITLE
fix: Restrict maximum AzureRM provider version for bootstrap module

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -51,14 +51,14 @@ resource "local_file" "this" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2, < 2.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.25, <= 3.95 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ### Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.25, <= 3.95 |
 
 ### Modules
 

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.25"
+      version = "~> 3.25, <= 3.95"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds a new AzureRM provider version constraint that limit maximum provider version to `3.95` in the `bootstrap` module (temporary solution). 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our examples utilising `bootstrap` module currently don't work with the newest AzureRM provider version (this is observed since version `3.96`). On HashiCorp side, it seems that they addressed this [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/25353) but the fix hasn't been released yet.

Once the problem is fixed on the HashiCorp side, we will switch to the newest AzureRM provider version.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
