### PR TITLE
docs: Tweak terraform-docs content template

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -23,13 +23,13 @@ content: |-
   {{- range .Module.Inputs }}
   {{- if .Required }}
   [`{{ .Name }}`](#{{ .Name }}) | `{{ (split "(" .Type.Raw)._0 }}` | {{ (split "." .Description.Raw)._0 }}.
-  {{- end -}}
-  {{ end }}
+  {{- end }}
+  {{- end }}
 
-  {{- $optional := false }}
-  {{- range .Module.Inputs }}{{ if not .Required }}{{ $optional = true }}{{ end }}{{ end }}
+  {{ $optional := false -}}
+  {{ range .Module.Inputs }}{{ if not .Required }}{{ $optional = true -}}{{ end -}}{{ end -}}
 
-  {{ if $optional }}
+  {{ if $optional -}}
   ## Module's Optional Inputs
 
   Name | Type | Description
@@ -38,10 +38,10 @@ content: |-
   {{- if not .Required }}
   [`{{ .Name }}`](#{{ .Name }}) | `{{ (split "(" .Type.Raw)._0 }}` | {{ (split "." .Description.Raw)._0 }}.
   {{- end -}}
-  {{ end }}
+  {{ end -}}
   {{ end }}
 
-  {{ if ne (len .Module.Outputs) 0 }}
+  {{ if ne (len .Module.Outputs) 0 -}}
   ## Module's Outputs
 
   Name |  Description
@@ -53,21 +53,21 @@ content: |-
 
   ## Module's Nameplate
 
-  {{ if ne (len .Module.Requirements) 0 }}
+  {{ if ne (len .Module.Requirements) 0 -}}
   Requirements needed by this module:
   {{ range .Module.Requirements }}
   - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
   {{- end }}
   {{- end }}
 
-  {{ if ne (len .Module.Providers) 0 }}
+  {{ if ne (len .Module.Providers) 0 -}}
   Providers used in this module:
   {{ range .Module.Providers }}
   - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
   {{- end }}
   {{- end }}
 
-  {{ if ne (len .Module.ModuleCalls) 0 }}
+  {{ if ne (len .Module.ModuleCalls) 0 -}}
   Modules used in this module:
   Name | Version | Source | Description
   --- | --- | --- | ---
@@ -76,7 +76,7 @@ content: |-
   {{- end }}
   {{- end }}
 
-  {{ if ne (len .Module.Resources) 0 }}
+  {{ if ne (len .Module.Resources) 0 -}}
   Resources used in this module:
   {{ range .Module.Resources }}
   - `{{ .Type }}` ({{ .Mode }})
@@ -87,7 +87,7 @@ content: |-
 
   ### Required Inputs
 
-  {{ range .Module.Inputs }}
+  {{ range .Module.Inputs -}}
   {{ if .Required -}}
   #### {{ .Name }}
 
@@ -101,13 +101,14 @@ content: |-
   {{ end }}
 
   <sup>[back to list](#modules-required-inputs)</sup>
-  {{ end }}
-  {{- end }}
+  
+  {{ end -}}
+  {{- end -}}
 
-  {{ if $optional }}
+  {{ if $optional -}}
   ### Optional Inputs
 
-  {{ range .Module.Inputs }}
+  {{ range .Module.Inputs -}}
   {{ if not .Required -}}
   #### {{ .Name }}
 
@@ -123,6 +124,7 @@ content: |-
   Default value: `{{ .Default }}`
 
   <sup>[back to list](#modules-optional-inputs)</sup>
+  
   {{ end }}
-  {{- end }}
-  {{ end }}
+  {{- end -}}
+  {{ end -}}

--- a/examples/appgw/README.md
+++ b/examples/appgw/README.md
@@ -14,7 +14,6 @@ Name | Type | Description
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 [`appgws`](#appgws) | `map` | A map defining all Application Gateways in the current deployment.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -25,26 +24,21 @@ Name | Type | Description
 
 
 
-
 ## Module's Nameplate
-
 
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 
-
 Providers used in this module:
 
 - `azurerm`
-
 
 Modules used in this module:
 Name | Version | Source | Description
 --- | --- | --- | ---
 `vnet` | - | ../../modules/vnet | 
 `appgw` | - | ../../modules/appgw | 
-
 
 Resources used in this module:
 
@@ -56,8 +50,6 @@ Resources used in this module:
 
 ### Required Inputs
 
-
-
 #### region
 
 The Azure region to use.
@@ -65,8 +57,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
 
 #### resource_group_name
 
@@ -322,10 +312,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
 ### Optional Inputs
-
 
 #### tags
 
@@ -336,7 +323,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### name_prefix
 
@@ -372,8 +358,5 @@ Type: bool
 Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
-
 
 <!-- END_TF_DOCS -->

--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -183,7 +183,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -200,8 +199,6 @@ Name | Type | Description
 [`bootstrap_storages`](#bootstrap_storages) | `map` | A map defining Azure Storage Accounts used to host file shares for bootstrapping NGFWs.
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
-
-
 
 ## Module's Outputs
 
@@ -221,18 +218,15 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
 - `local`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -247,7 +241,6 @@ Name | Version | Source | Description
 `vmseries` | - | ../../modules/vmseries | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
 
-
 Resources used in this module:
 
 - `availability_set` (managed)
@@ -259,9 +252,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -278,7 +268,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -353,19 +342,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -403,8 +380,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -414,7 +389,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### vnet_peerings
 

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -214,7 +214,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -229,8 +228,6 @@ Name | Type | Description
 [`ngfw_metrics`](#ngfw_metrics) | `object` | A map controlling metrics-relates resources.
 [`scale_sets`](#scale_sets) | `map` | A map defining Azure Virtual Machine Scale Sets based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
-
-
 
 ## Module's Outputs
 
@@ -247,17 +244,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -271,7 +265,6 @@ Name | Version | Source | Description
 `vmss` | - | ../../modules/vmss | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
 
-
 Resources used in this module:
 
 - `resource_group` (managed)
@@ -281,9 +274,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -300,7 +290,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -375,17 +364,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -423,8 +402,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -434,7 +411,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### vnet_peerings
 

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -187,7 +187,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -203,8 +202,6 @@ Name | Type | Description
 [`bootstrap_storages`](#bootstrap_storages) | `map` | A map defining Azure Storage Accounts used to host file shares for bootstrapping NGFWs.
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
-
-
 
 ## Module's Outputs
 
@@ -224,18 +221,15 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
 - `local`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -249,7 +243,6 @@ Name | Version | Source | Description
 `vmseries` | - | ../../modules/vmseries | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
 
-
 Resources used in this module:
 
 - `availability_set` (managed)
@@ -261,9 +254,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -280,7 +270,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -355,18 +344,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -404,8 +382,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -415,7 +391,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### natgws
 

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -208,7 +208,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -222,8 +221,6 @@ Name | Type | Description
 [`ngfw_metrics`](#ngfw_metrics) | `object` | A map controlling metrics-relates resources.
 [`scale_sets`](#scale_sets) | `map` | A map defining Azure Virtual Machine Scale Sets based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
-
-
 
 ## Module's Outputs
 
@@ -240,17 +237,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -263,7 +257,6 @@ Name | Version | Source | Description
 `vmss` | - | ../../modules/vmss | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
 
-
 Resources used in this module:
 
 - `resource_group` (managed)
@@ -273,9 +266,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -292,7 +282,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -367,16 +356,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -414,8 +394,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -425,7 +403,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### natgws
 

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -130,7 +130,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -145,8 +144,6 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -160,18 +157,15 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
 - `local`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -182,7 +176,6 @@ Name | Version | Source | Description
 `bootstrap` | - | ../../modules/bootstrap | 
 `vmseries` | - | ../../modules/vmseries | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
-
 
 Resources used in this module:
 
@@ -195,9 +188,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -214,7 +204,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -289,16 +278,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -336,8 +316,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -347,7 +325,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### gateway_load_balancers
 

--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -128,7 +128,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -138,8 +137,6 @@ Name | Type | Description
 [`tags`](#tags) | `map` | Map of tags to assign to the created resources.
 [`availability_sets`](#availability_sets) | `map` | A map defining availability sets.
 [`panoramas`](#panoramas) | `map` | A map defining Azure Virtual Machine based on Palo Alto Networks Panorama image.
-
-
 
 ## Module's Outputs
 
@@ -151,24 +148,20 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
 
-
 Modules used in this module:
 Name | Version | Source | Description
 --- | --- | --- | ---
 `vnet` | - | ../../modules/vnet | 
 `panorama` | - | ../../modules/panorama | 
-
 
 Resources used in this module:
 
@@ -180,9 +173,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -199,7 +189,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -274,12 +263,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -317,8 +301,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -328,7 +310,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### availability_sets
 

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -121,7 +121,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -138,8 +137,6 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -155,18 +152,15 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-
 
 Providers used in this module:
 
 - `random`
 - `azurerm`
 - `local`
-
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -180,7 +174,6 @@ Name | Version | Source | Description
 `vmseries` | - | ../../modules/vmseries | 
 `test_infrastructure` | - | ../../modules/test_infrastructure | 
 
-
 Resources used in this module:
 
 - `availability_set` (managed)
@@ -192,9 +185,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -211,7 +201,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -286,18 +275,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -335,8 +313,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -346,7 +322,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### natgws
 

--- a/examples/virtual_network_gateway/README.md
+++ b/examples/virtual_network_gateway/README.md
@@ -13,7 +13,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -22,8 +21,6 @@ Name | Type | Description
 [`create_resource_group`](#create_resource_group) | `bool` | When set to `true` it will cause a Resource Group creation.
 [`tags`](#tags) | `map` | Map of tags to assign to the created resources.
 [`virtual_network_gateways`](#virtual_network_gateways) | `map` | Map of Virtual Network Gateways to create.
-
-
 
 ## Module's Outputs
 
@@ -34,23 +31,19 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 
-
 Providers used in this module:
 
 - `azurerm`
-
 
 Modules used in this module:
 Name | Version | Source | Description
 --- | --- | --- | ---
 `vnet` | - | ../../modules/vnet | 
 `vng` | - | ../../modules/virtual_network_gateway | 
-
 
 Resources used in this module:
 
@@ -60,9 +53,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
-
 
 #### resource_group_name
 
@@ -79,7 +69,6 @@ The Azure region to use.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -154,11 +143,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
 ### Optional Inputs
-
 
 #### name_prefix
 
@@ -196,8 +181,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 Map of tags to assign to the created resources.
@@ -207,7 +190,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### virtual_network_gateways
 

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -823,7 +823,6 @@ Name | Type | Description
 [`listeners`](#listeners) | `map` | A map of listeners for the Application Gateway.
 [`rules`](#rules) | `map` | A map of rules for the Application Gateway.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -844,8 +843,6 @@ Name | Type | Description
 [`redirects`](#redirects) | `map` | A map of redirects for the Application Gateway.
 [`url_path_maps`](#url_path_maps) | `map` | A map of URL path maps for the Application Gateway.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -856,17 +853,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -879,7 +873,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -905,7 +898,6 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
 #### subnet_id
 
 An ID of a subnet (must be dedicated to Application Gateway v2) that will host the Application Gateway.
@@ -913,7 +905,6 @@ An ID of a subnet (must be dedicated to Application Gateway v2) that will host t
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### public_ip
 
@@ -938,13 +929,6 @@ object({
 
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
-
-
-
-
-
 
 #### frontend_ip_configuration_name
 
@@ -995,12 +979,6 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
 #### rules
 
 A map of rules for the Application Gateway. A rule combines backend's, listener's, rewrites' and redirects' configurations.
@@ -1040,13 +1018,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -1057,7 +1029,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### zones
 
@@ -1081,7 +1052,6 @@ Type: list(string)
 Default value: `[1 2 3]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### domain_name_label
 
@@ -1247,8 +1217,6 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
 
 #### backend_pool
 
@@ -1483,6 +1451,5 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 <!-- END_TF_DOCS -->

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -135,7 +135,6 @@ Name | Type | Description
 [`name`](#name) | `string` | Name of the Storage Account.
 [`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -147,8 +146,6 @@ Name | Type | Description
 [`file_shares_configuration`](#file_shares_configuration) | `object` | A map defining common File Share setting.
 [`file_shares`](#file_shares) | `map` | Definition of File Shares.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -159,17 +156,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -186,7 +180,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -209,18 +202,7 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
-
-
 
 #### region
 

--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -90,7 +90,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
 [`frontend_ip`](#frontend_ip) | `object` | Frontend IP configuration of the Gateway Load Balancer.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -101,8 +100,6 @@ Name | Type | Description
 [`backends`](#backends) | `map` | Map with backend configurations for the Gateway Load Balancer.
 [`lb_rule`](#lb_rule) | `object` | Load balancing rule configuration.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -112,17 +109,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -136,7 +130,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -161,8 +154,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
 
 #### frontend_ip
 
@@ -190,16 +181,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -224,7 +206,6 @@ Type: list(string)
 Default value: `[1 2 3]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### health_probe
 

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -93,7 +93,6 @@ Name | Type | Description
 [`backend_name`](#backend_name) | `string` | The name of the backend pool to create.
 [`frontend_ips`](#frontend_ips) | `map` | A map of objects describing Load Balancer Frontend IP configurations with respective inbound and outbound rules.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -102,8 +101,6 @@ Name | Type | Description
 [`zones`](#zones) | `list` | Controls zones for Load Balancer's fronted IP configurations.
 [`health_probes`](#health_probes) | `map` | Backend's health probe definition.
 [`nsg_auto_rules_settings`](#nsg_auto_rules_settings) | `object` | Controls automatic creation of NSG rules for all defined inbound rules.
-
-
 
 ## Module's Outputs
 
@@ -117,17 +114,14 @@ private IP address otherwise.
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -145,7 +139,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -170,8 +163,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
 
 #### backend_name
 
@@ -341,15 +332,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -383,8 +366,6 @@ Type: list(string)
 Default value: `[1 2 3]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
 
 #### health_probes
 

--- a/modules/name_templater/README.md
+++ b/modules/name_templater/README.md
@@ -59,14 +59,11 @@ Name | Type | Description
 [`name_prefix`](#name_prefix) | `string` | Prefix used in names for the resources.
 [`name_template`](#name_template) | `object` | A name template definition.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`abbreviations`](#abbreviations) | `map` | Map of abbreviations used for resources (placed in place of "__default__").
-
-
 
 ## Module's Outputs
 
@@ -76,17 +73,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `random`, version: ~> 3.5
 
-
 Providers used in this module:
 
 - `random`, version: ~> 3.5
-
 
 
 
@@ -97,7 +91,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### resource_type
 
@@ -174,14 +167,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### abbreviations
 

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -48,7 +48,6 @@ Name | Type | Description
 [`region`](#region) | `string` | Azure region.
 [`subnet_ids`](#subnet_ids) | `map` | A map of subnet IDs what will be bound with this NAT Gateway.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -60,8 +59,6 @@ Name | Type | Description
 [`public_ip`](#public_ip) | `object` | A map defining a Public IP resource.
 [`public_ip_prefix`](#public_ip_prefix) | `object` | A map defining a Public IP Prefix resource.
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -71,17 +68,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -100,7 +94,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -126,7 +119,6 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
 #### subnet_ids
 
 A map of subnet IDs what will be bound with this NAT Gateway.
@@ -138,18 +130,7 @@ Type: map(string)
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -160,7 +141,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### create_natgw
 

--- a/modules/ngfw_metrics/README.md
+++ b/modules/ngfw_metrics/README.md
@@ -64,7 +64,6 @@ Name | Type | Description
 [`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
 [`application_insights`](#application_insights) | `map` | A map defining Application Insights instances.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -72,8 +71,6 @@ Name | Type | Description
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`create_workspace`](#create_workspace) | `bool` | Controls creation or sourcing of a Log Analytics Workspace.
 [`log_analytics_workspace`](#log_analytics_workspace) | `object` | Configuration of the log analytics workspace.
-
-
 
 ## Module's Outputs
 
@@ -84,17 +81,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -107,7 +101,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -132,9 +125,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
-
 
 #### application_insights
 
@@ -166,13 +156,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -222,6 +206,5 @@ object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 <!-- END_TF_DOCS -->

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -30,15 +30,12 @@ Name | Type | Description
 [`virtual_machine`](#virtual_machine) | `object` | Firewall parameters configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interface specifications.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`logging_disks`](#logging_disks) | `map` |  A map of objects describing the additional disks configuration.
-
-
 
 ## Module's Outputs
 
@@ -50,17 +47,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -76,7 +70,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -101,7 +94,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### authentication
 
@@ -299,14 +291,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -317,10 +302,6 @@ Type: map(any)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
-
-
 
 #### logging_disks
 

--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -324,7 +324,6 @@ Name | Type | Description
 [`instance_settings`](#instance_settings) | `object` | A map containing the basic Virtual Network Gateway instance settings.
 [`ip_configurations`](#ip_configurations) | `object` | A map defining the Public IPs used by the Virtual Network Gateway.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -339,8 +338,6 @@ Name | Type | Description
 [`local_network_gateways`](#local_network_gateways) | `map` | Map of local network gateways and their connections.
 [`vpn_clients`](#vpn_clients) | `map` | VPN client configurations (IPSec point-to-site connections).
 
-
-
 ## Module's Outputs
 
 Name |  Description
@@ -350,17 +347,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -375,7 +369,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -401,7 +394,6 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
 #### subnet_id
 
 An ID of a Subnet in which the Virtual Network Gateway will be created.
@@ -412,8 +404,6 @@ This has to be a dedicated Subnet named `GatewaySubnet`.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-
 
 #### instance_settings
 
@@ -527,19 +517,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -550,7 +528,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### zones
 
@@ -575,8 +552,6 @@ Type: string
 Default value: `&{}`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
 
 #### private_ip_address_enabled
 

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -44,14 +44,11 @@ Name | Type | Description
 [`virtual_machine`](#virtual_machine) | `object` | Firewall parameters configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interface specifications.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
-
-
 
 ## Module's Outputs
 
@@ -65,17 +62,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -90,7 +84,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -115,7 +108,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### authentication
 
@@ -336,13 +328,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -353,9 +339,5 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
-
-
 
 <!-- END_TF_DOCS -->

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -110,7 +110,6 @@ Name | Type | Description
 [`image`](#image) | `object` | Basic Azure VM configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interfaces specifications.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -119,8 +118,6 @@ Name | Type | Description
 [`virtual_machine_scale_set`](#virtual_machine_scale_set) | `object` | Scale set parameters configuration.
 [`autoscaling_configuration`](#autoscaling_configuration) | `object` | Autoscaling configuration common to all policies.
 [`autoscaling_profiles`](#autoscaling_profiles) | `list` | A list defining autoscaling profiles.
-
-
 
 ## Module's Outputs
 
@@ -132,23 +129,19 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 Modules used in this module:
 Name | Version | Source | Description
 --- | --- | --- | ---
 `ptd_time` | - | ./dt_string_converter | 
-
 
 Resources used in this module:
 
@@ -158,7 +151,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -183,7 +175,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### authentication
 
@@ -258,7 +249,6 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
 #### interfaces
 
 List of the network interfaces specifications.
@@ -321,15 +311,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 
@@ -340,8 +322,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
 
 #### virtual_machine_scale_set
 
@@ -421,7 +401,6 @@ object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### autoscaling_configuration
 

--- a/modules/vmss/dt_string_converter/README.md
+++ b/modules/vmss/dt_string_converter/README.md
@@ -15,7 +15,6 @@ Name | Type | Description
 
 
 
-
 ## Module's Outputs
 
 Name |  Description
@@ -36,7 +35,6 @@ Name |  Description
 
 ### Required Inputs
 
-
 #### time
 
 The time value in minutes to be converted to string representation.
@@ -44,6 +42,5 @@ The time value in minutes to be converted to string representation.
 Type: number
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 <!-- END_TF_DOCS -->

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -130,7 +130,6 @@ Name | Type | Description
 [`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
 [`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -142,8 +141,6 @@ Name | Type | Description
 [`route_tables`](#route_tables) | `map` | Map of objects describing a Route Tables.
 [`create_subnets`](#create_subnets) | `bool` | Controls subnet creation.
 [`subnets`](#subnets) | `map` | Map of objects describing subnets to manage.
-
-
 
 ## Module's Outputs
 
@@ -158,17 +155,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -188,7 +182,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### name
 
@@ -214,20 +207,7 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
-
-
-
-
-
-
-
 ### Optional Inputs
-
-
-
-
 
 #### tags
 

--- a/modules/vnet_peering/README.md
+++ b/modules/vnet_peering/README.md
@@ -30,7 +30,6 @@ Name | Type | Description
 
 
 
-
 ## Module's Outputs
 
 Name |  Description
@@ -42,17 +41,14 @@ Name |  Description
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-
 Providers used in this module:
 
 - `azurerm`, version: ~> 3.98
-
 
 
 
@@ -66,7 +62,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
 
 #### local_peer_config
 
@@ -135,6 +130,5 @@ object({
 
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
## Description

Adjust terraform-docs config (content template) to get rid of extra empty lines.

## Motivation and Context

Get rid of extra empty lines.

## How Has This Been Tested?

Generate READMEs and verify.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
