### PR TITLE
refactor: Fix README generation for internal submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,11 @@ repos:
     - --args=--config=.terraform-docs.yml
     id: terraform_docs
   - args:
+    - --args=--config=.terraform-docs-internal.yml
+    - --hook-config=--path-to-file=.README.md
+    files: ^modules/test_infrastructure/
+    id: terraform_docs
+  - args:
     - --args=--only=terraform_deprecated_interpolation
     - --args=--only=terraform_deprecated_index
     - --args=--only=terraform_module_pinned_source

--- a/.terraform-docs-internal.yml
+++ b/.terraform-docs-internal.yml
@@ -1,0 +1,130 @@
+formatter: "markdown document" # this is required
+version: ""
+header-from: ".header.md"
+
+output:
+  file: .README.md
+  mode: replace
+
+sort:
+  enabled: false
+
+settings:
+  indent: 3
+  lockfile: false
+
+content: |-
+  {{ .Header }}
+
+  ## Module's Required Inputs
+
+  Name | Type | Description
+  --- | --- | ---
+  {{- range .Module.Inputs }}
+  {{- if .Required }}
+  [`{{ .Name }}`](#{{ .Name }}) | `{{ (split "(" .Type.Raw)._0 }}` | {{ (split "." .Description.Raw)._0 }}.
+  {{- end }}
+  {{- end }}
+
+  {{ $optional := false -}}
+  {{ range .Module.Inputs }}{{ if not .Required }}{{ $optional = true -}}{{ end -}}{{ end -}}
+
+  {{ if $optional -}}
+  ## Module's Optional Inputs
+
+  Name | Type | Description
+  --- | --- | ---
+  {{- range .Module.Inputs }}
+  {{- if not .Required }}
+  [`{{ .Name }}`](#{{ .Name }}) | `{{ (split "(" .Type.Raw)._0 }}` | {{ (split "." .Description.Raw)._0 }}.
+  {{- end -}}
+  {{ end -}}
+  {{ end }}
+
+  {{ if ne (len .Module.Outputs) 0 -}}
+  ## Module's Outputs
+
+  Name |  Description
+  --- | ---
+  {{- range .Module.Outputs }}
+  `{{ .Name }}` | {{ .Description.Raw }}
+  {{- end }}
+  {{- end }}
+
+  ## Module's Nameplate
+
+  {{ if ne (len .Module.Requirements) 0 -}}
+  Requirements needed by this module:
+  {{ range .Module.Requirements }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Providers) 0 -}}
+  Providers used in this module:
+  {{ range .Module.Providers }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.ModuleCalls) 0 -}}
+  Modules used in this module:
+  Name | Version | Source | Description
+  --- | --- | --- | ---
+  {{- range .Module.ModuleCalls }}
+  `{{ .Name }}` | {{ if .Version }}{{ .Version }}{{ else }}-{{ end }} | {{ .Source }} | {{ .Description }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Resources) 0 -}}
+  Resources used in this module:
+  {{ range .Module.Resources }}
+  - `{{ .Type }}` ({{ .Mode }})
+  {{- end }}
+  {{- end }}
+
+  ## Inputs/Outpus details
+
+  ### Required Inputs
+
+  {{ range .Module.Inputs -}}
+  {{ if .Required -}}
+  #### {{ .Name }}
+
+  {{ .Description }}
+
+  Type: {{ if lt (len (split "\n" .Type.Raw)) 2 }}{{ .Type }}{{ else }}
+
+  ```hcl
+  {{ .Type }}
+  ```
+  {{ end }}
+
+  <sup>[back to list](#modules-required-inputs)</sup>
+  
+  {{ end -}}
+  {{- end -}}
+
+  {{ if $optional -}}
+  ### Optional Inputs
+
+  {{ range .Module.Inputs -}}
+  {{ if not .Required -}}
+  #### {{ .Name }}
+
+  {{ .Description }}
+
+  Type: {{ if lt (len (split "\n" .Type.Raw)) 2 }}{{ .Type }}{{ else }}
+
+  ```hcl
+  {{ .Type }}
+  ```
+  {{ end }}
+
+  Default value: `{{ .Default }}`
+
+  <sup>[back to list](#modules-optional-inputs)</sup>
+  
+  {{ end }}
+  {{- end -}}
+  {{ end -}}

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -20,7 +20,6 @@ Name | Type | Description
 [`spoke_vms`](#spoke_vms) | `map` | A map defining spoke VMs for testing.
 [`bastions`](#bastions) | `map` | A map containing Azure Bastion definition.
 
-
 ## Module's Optional Inputs
 
 Name | Type | Description
@@ -28,8 +27,6 @@ Name | Type | Description
 [`create_resource_group`](#create_resource_group) | `bool` | When set to `true` it will cause a Resource Group creation.
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`load_balancers`](#load_balancers) | `map` | A map containing configuration for all (both private and public) Load Balancers.
-
-
 
 ## Module's Outputs
 
@@ -42,17 +39,14 @@ private IP address otherwise.
 
 ## Module's Nameplate
 
-
 Requirements needed by this module:
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.80
-
+- `azurerm`, version: ~> 3.98
 
 Providers used in this module:
 
-- `azurerm`, version: ~> 3.80
-
+- `azurerm`, version: ~> 3.98
 
 Modules used in this module:
 Name | Version | Source | Description
@@ -60,7 +54,6 @@ Name | Version | Source | Description
 `vnet` | - | ../vnet | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet
 `vnet_peering` | - | ../vnet_peering | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet_peering
 `load_balancer` | - | ../loadbalancer | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/loadbalancer
-
 
 Resources used in this module:
 
@@ -75,8 +68,6 @@ Resources used in this module:
 ## Inputs/Outpus details
 
 ### Required Inputs
-
-
 
 #### resource_group_name
 
@@ -93,7 +84,6 @@ The name of the Azure region to deploy the resources in.
 Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### vnets
 
@@ -170,7 +160,6 @@ map(object({
 
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
 
 #### authentication
 
@@ -278,10 +267,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-
-
 ### Optional Inputs
-
 
 #### create_resource_group
 
@@ -296,8 +282,6 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-
-
 #### tags
 
 The map of tags to assign to all created resources.
@@ -307,7 +291,6 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
 
 #### load_balancers
 
@@ -407,8 +390,5 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-
-
 
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We introduced `test_infrastructure` module as internal submodule from TF Registry perspective. This means that module's README file should have a leading dot in its name (`.README.md`). We needed to automate the generation of README files for internal submodules.

This PR introduces separate **terraform-docs configuration file** for internal submodules and additional **terraform-docs hook in pre-commit configuration file** for `test_infrastructure` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#30 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally with `pre-commit` command.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

The terraform-docs hook is ran twice now, like that:

<img width="623" alt="Screenshot 2024-04-24 at 12 03 31" src="https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/assets/135693994/346adbed-6de2-4e8f-a148-bba8efb755f0">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
