### PR TITLE
fix: Fix hub_sync workflow & README files generation

### DIFF
--- a/.github/workflows/hub_sync.yml
+++ b/.github/workflows/hub_sync.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   hub_sync:

--- a/.github/workflows/hub_sync.yml
+++ b/.github/workflows/hub_sync.yml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
+  schedule:
+    - cron: "0 3 * * 4" # this means every Thursday @3am UTC
 
 jobs:
   hub_sync:

--- a/.terraform-docs-internal.yml
+++ b/.terraform-docs-internal.yml
@@ -5,6 +5,8 @@ header-from: ".header.md"
 output:
   file: .README.md
   mode: replace
+  template: |-
+    {{ .Content }}
 
 sort:
   enabled: false
@@ -12,11 +14,44 @@ sort:
 settings:
   indent: 3
   lockfile: false
+  escape: false
 
 content: |-
   {{ .Header }}
 
-  ## Module's Required Inputs
+  ## Reference
+
+  {{ if ne (len .Module.Requirements) 0 -}}
+  ### Requirements
+  {{ range .Module.Requirements }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Providers) 0 -}}
+  ### Providers
+  {{ range .Module.Providers }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.ModuleCalls) 0 -}}
+  ### Modules
+  Name | Version | Source | Description
+  --- | --- | --- | ---
+  {{- range .Module.ModuleCalls }}
+  `{{ .Name }}` | {{ if .Version }}{{ .Version }}{{ else }}-{{ end }} | {{ .Source }} | {{ .Description }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Resources) 0 -}}
+  ### Resources
+  {{ range .Module.Resources }}
+  - `{{ .Type }}` ({{ .Mode }})
+  {{- end }}
+  {{- end }}
+
+  ### Required Inputs
 
   Name | Type | Description
   --- | --- | ---
@@ -30,7 +65,7 @@ content: |-
   {{ range .Module.Inputs }}{{ if not .Required }}{{ $optional = true -}}{{ end -}}{{ end -}}
 
   {{ if $optional -}}
-  ## Module's Optional Inputs
+  ### Optional Inputs
 
   Name | Type | Description
   --- | --- | ---
@@ -42,7 +77,7 @@ content: |-
   {{ end }}
 
   {{ if ne (len .Module.Outputs) 0 -}}
-  ## Module's Outputs
+  ### Outputs
 
   Name |  Description
   --- | ---
@@ -51,41 +86,7 @@ content: |-
   {{- end }}
   {{- end }}
 
-  ## Module's Nameplate
-
-  {{ if ne (len .Module.Requirements) 0 -}}
-  Requirements needed by this module:
-  {{ range .Module.Requirements }}
-  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.Providers) 0 -}}
-  Providers used in this module:
-  {{ range .Module.Providers }}
-  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.ModuleCalls) 0 -}}
-  Modules used in this module:
-  Name | Version | Source | Description
-  --- | --- | --- | ---
-  {{- range .Module.ModuleCalls }}
-  `{{ .Name }}` | {{ if .Version }}{{ .Version }}{{ else }}-{{ end }} | {{ .Source }} | {{ .Description }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.Resources) 0 -}}
-  Resources used in this module:
-  {{ range .Module.Resources }}
-  - `{{ .Type }}` ({{ .Mode }})
-  {{- end }}
-  {{- end }}
-
-  ## Inputs/Outpus details
-
-  ### Required Inputs
+  ### Required Inputs details
 
   {{ range .Module.Inputs -}}
   {{ if .Required -}}
@@ -106,7 +107,7 @@ content: |-
   {{- end -}}
 
   {{ if $optional -}}
-  ### Optional Inputs
+  ### Optional Inputs details
 
   {{ range .Module.Inputs -}}
   {{ if not .Required -}}

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -5,6 +5,8 @@ header-from: ".header.md"
 output:
   file: README.md
   mode: replace
+  template: |-
+    {{ .Content }}
 
 sort:
   enabled: false
@@ -12,11 +14,44 @@ sort:
 settings:
   indent: 3
   lockfile: false
+  escape: false
 
 content: |-
   {{ .Header }}
 
-  ## Module's Required Inputs
+  ## Reference
+
+  {{ if ne (len .Module.Requirements) 0 -}}
+  ### Requirements
+  {{ range .Module.Requirements }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Providers) 0 -}}
+  ### Providers
+  {{ range .Module.Providers }}
+  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.ModuleCalls) 0 -}}
+  ### Modules
+  Name | Version | Source | Description
+  --- | --- | --- | ---
+  {{- range .Module.ModuleCalls }}
+  `{{ .Name }}` | {{ if .Version }}{{ .Version }}{{ else }}-{{ end }} | {{ .Source }} | {{ .Description }}
+  {{- end }}
+  {{- end }}
+
+  {{ if ne (len .Module.Resources) 0 -}}
+  ### Resources
+  {{ range .Module.Resources }}
+  - `{{ .Type }}` ({{ .Mode }})
+  {{- end }}
+  {{- end }}
+
+  ### Required Inputs
 
   Name | Type | Description
   --- | --- | ---
@@ -30,7 +65,7 @@ content: |-
   {{ range .Module.Inputs }}{{ if not .Required }}{{ $optional = true -}}{{ end -}}{{ end -}}
 
   {{ if $optional -}}
-  ## Module's Optional Inputs
+  ### Optional Inputs
 
   Name | Type | Description
   --- | --- | ---
@@ -42,7 +77,7 @@ content: |-
   {{ end }}
 
   {{ if ne (len .Module.Outputs) 0 -}}
-  ## Module's Outputs
+  ### Outputs
 
   Name |  Description
   --- | ---
@@ -51,41 +86,7 @@ content: |-
   {{- end }}
   {{- end }}
 
-  ## Module's Nameplate
-
-  {{ if ne (len .Module.Requirements) 0 -}}
-  Requirements needed by this module:
-  {{ range .Module.Requirements }}
-  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.Providers) 0 -}}
-  Providers used in this module:
-  {{ range .Module.Providers }}
-  - `{{ .Name }}`{{ if .Version }}, version: {{ .Version }}{{ end }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.ModuleCalls) 0 -}}
-  Modules used in this module:
-  Name | Version | Source | Description
-  --- | --- | --- | ---
-  {{- range .Module.ModuleCalls }}
-  `{{ .Name }}` | {{ if .Version }}{{ .Version }}{{ else }}-{{ end }} | {{ .Source }} | {{ .Description }}
-  {{- end }}
-  {{- end }}
-
-  {{ if ne (len .Module.Resources) 0 -}}
-  Resources used in this module:
-  {{ range .Module.Resources }}
-  - `{{ .Type }}` ({{ .Mode }})
-  {{- end }}
-  {{- end }}
-
-  ## Inputs/Outpus details
-
-  ### Required Inputs
+  ### Required Inputs details
 
   {{ range .Module.Inputs -}}
   {{ if .Required -}}
@@ -106,7 +107,7 @@ content: |-
   {{- end -}}
 
   {{ if $optional -}}
-  ### Optional Inputs
+  ### Optional Inputs details
 
   {{ range .Module.Inputs -}}
   {{ if not .Required -}}

--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Common Firewall Option
+short_title: Common Firewall Option
 type: refarch
-show\_in\_hub: true
+show_in_hub: true
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture. Common NGFW Option
 
@@ -175,7 +174,40 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+- `local`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`natgw` | - | ../../modules/natgw | 
+`load_balancer` | - | ../../modules/loadbalancer | 
+`appgw` | - | ../../modules/appgw | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`bootstrap` | - | ../../modules/bootstrap | 
+`vmseries` | - | ../../modules/vmseries | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `availability_set` (managed)
+- `resource_group` (managed)
+- `file` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -183,7 +215,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -200,7 +232,7 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -216,42 +248,7 @@ Name |  Description
 `test_vms_ips` | IP Addresses of the test VMs.
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-- `local`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`natgw` | - | ../../modules/natgw | 
-`load_balancer` | - | ../../modules/loadbalancer | 
-`appgw` | - | ../../modules/appgw | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`bootstrap` | - | ../../modules/bootstrap | 
-`vmseries` | - | ../../modules/vmseries | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `availability_set` (managed)
-- `resource_group` (managed)
-- `file` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -342,7 +339,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -1329,5 +1326,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Common Firewall Option with Autoscaling
+short_title: Common Firewall Option with Autoscaling
 type: refarch
-show\_in\_hub: true
+show_in_hub: true
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Common NGFW Option with Autoscaling
 
@@ -19,7 +18,7 @@ Virtual Machine Scale Sets (VMSS) are used for autoscaling to run the Next Gener
 metrics published by PanOS it is possible to adjust the number of firewall appliances to the current workload (data plane
 utilization). Since firewalls are added or removed automatically, they cannot be managed in a classic way. To ease licensing,
 management and updates a Panorama appliance is suggested. Deployment of a Panorama instance is not covered in this example,
-but a [dedicated one exists](../standalone\\_panorama/README.md).
+but a [dedicated one exists](../standalone\_panorama/README.md).
 
 ## Reference Architecture Design
 
@@ -206,7 +205,36 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`natgw` | - | ../../modules/natgw | 
+`load_balancer` | - | ../../modules/loadbalancer | 
+`appgw` | - | ../../modules/appgw | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`vmss` | - | ../../modules/vmss | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `resource_group` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -214,7 +242,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -229,7 +257,7 @@ Name | Type | Description
 [`scale_sets`](#scale_sets) | `map` | A map defining Azure Virtual Machine Scale Sets based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -242,38 +270,7 @@ Name |  Description
 `test_vms_ips` | IP Addresses of the test VMs.
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`natgw` | - | ../../modules/natgw | 
-`load_balancer` | - | ../../modules/loadbalancer | 
-`appgw` | - | ../../modules/appgw | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`vmss` | - | ../../modules/vmss | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `resource_group` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -364,7 +361,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -1223,5 +1220,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Dedicated Firewall Option
+short_title: Dedicated Firewall Option
 type: refarch
-show\_in\_hub: true
+show_in_hub: true
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option
 
@@ -179,7 +178,40 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+- `local`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`natgw` | - | ../../modules/natgw | 
+`load_balancer` | - | ../../modules/loadbalancer | 
+`appgw` | - | ../../modules/appgw | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`bootstrap` | - | ../../modules/bootstrap | 
+`vmseries` | - | ../../modules/vmseries | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `availability_set` (managed)
+- `resource_group` (managed)
+- `file` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -187,7 +219,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -204,7 +236,7 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -220,42 +252,7 @@ Name |  Description
 `test_vms_ips` | IP Addresses of the test VMs.
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-- `local`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`natgw` | - | ../../modules/natgw | 
-`load_balancer` | - | ../../modules/loadbalancer | 
-`appgw` | - | ../../modules/appgw | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`bootstrap` | - | ../../modules/bootstrap | 
-`vmseries` | - | ../../modules/vmseries | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `availability_set` (managed)
-- `resource_group` (managed)
-- `file` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -346,7 +343,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -1333,5 +1330,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Dedicated Firewall Option with Autoscaling
+short_title: Dedicated Firewall Option with Autoscaling
 type: refarch
-show\_in\_hub: true
+show_in_hub: true
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option with Autoscaling
 
@@ -19,7 +18,7 @@ Virtual Machine Scale Sets (VMSS) are used for autoscaling to run the Next Gener
 metrics published by PanOS it is possible to adjust the number of firewall appliances to the current workload (data plane
 utilization). Since firewalls are added or removed automatically, they cannot be managed in a classic way. Therefore they are not
 assigned with public IP addresses. To ease licensing, management and updates a Panorama appliance is suggested. Deployment of a
-Panorama instance is not covered in this example, but a [dedicated one exists](../standalone\_panorama/README.md).
+Panorama instance is not covered in this example, but a [dedicated one exists](../standalone_panorama/README.md).
 
 ## Reference Architecture Design
 
@@ -200,7 +199,36 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`natgw` | - | ../../modules/natgw | 
+`load_balancer` | - | ../../modules/loadbalancer | 
+`appgw` | - | ../../modules/appgw | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`vmss` | - | ../../modules/vmss | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `resource_group` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -208,7 +236,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -223,7 +251,7 @@ Name | Type | Description
 [`scale_sets`](#scale_sets) | `map` | A map defining Azure Virtual Machine Scale Sets based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -236,38 +264,7 @@ Name |  Description
 `test_vms_ips` | IP Addresses of the test VMs.
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`natgw` | - | ../../modules/natgw | 
-`load_balancer` | - | ../../modules/loadbalancer | 
-`appgw` | - | ../../modules/appgw | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`vmss` | - | ../../modules/vmss | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `resource_group` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -358,7 +355,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -1217,5 +1214,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: GWLB Firewall Option
+short_title: GWLB Firewall Option
 type: example
-show\_in\_hub: false
+show_in_hub: false
 ---
 # VM-Series Azure Gateway Load Balancer example
 
@@ -122,7 +121,38 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+- `local`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`gwlb` | - | ../../modules/gwlb | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`bootstrap` | - | ../../modules/bootstrap | 
+`vmseries` | - | ../../modules/vmseries | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `availability_set` (managed)
+- `resource_group` (managed)
+- `file` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -130,7 +160,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -145,7 +175,7 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -159,40 +189,7 @@ Name |  Description
 `test_vms_ips` | IP Addresses of the test VMs.
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-- `local`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`gwlb` | - | ../../modules/gwlb | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`bootstrap` | - | ../../modules/bootstrap | 
-`vmseries` | - | ../../modules/vmseries | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `availability_set` (managed)
-- `resource_group` (managed)
-- `file` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -283,7 +280,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -985,5 +982,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Standalone Panorama Deployment
+short_title: Standalone Panorama Deployment
 type: example
-show\_in\_hub: true
+show_in_hub: true
 ---
 # Standalone Panorama Deployment
 
@@ -13,7 +12,7 @@ location.
 
 The Terraform code presented here will deploy Palo Alto Networks Panorama management platform in Azure in management only mode
 (without additional logging disks). For option on how to add additional logging disks - please refer to panorama
-[module documentation](../../modules/panorama/README.md#input\_logging\_disks).
+[module documentation](../../modules/panorama/README.md#input_logging_disks).
 
 ## Topology
 
@@ -120,7 +119,31 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`panorama` | - | ../../modules/panorama | 
+
+### Resources
+
+- `availability_set` (managed)
+- `resource_group` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -128,7 +151,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -138,7 +161,7 @@ Name | Type | Description
 [`availability_sets`](#availability_sets) | `map` | A map defining availability sets.
 [`panoramas`](#panoramas) | `map` | A map defining Azure Virtual Machine based on Palo Alto Networks Panorama image.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -146,33 +169,7 @@ Name |  Description
 `password` | Initial administrative password to use for VM-Series.
 `panorama_mgmt_ips` | 
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`panorama` | - | ../../modules/panorama | 
-
-Resources used in this module:
-
-- `availability_set` (managed)
-- `resource_group` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -263,7 +260,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -456,5 +453,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/examples/standalone_vmseries/.header.md
+++ b/examples/standalone_vmseries/.header.md
@@ -10,8 +10,8 @@ An example of a Terraform module that deploys a Next Generation Firewall applian
 **NOTE:**
 
 - after the deployment firewall remains not licensed and not configured
-- this example contains some **files*- that **can contain sensitive data**, namely the `TFVARS` file can contain bootstrap_options
-  properties in `var.vmseries` definition. Keep in mind that **this code*- is **only an example**. It's main purpose is to
+- this example contains some **files** that **can contain sensitive data**, namely the `TFVARS` file can contain bootstrap_options
+  properties in `var.vmseries` definition. Keep in mind that **this code** is **only an example**. It's main purpose is to
   introduce the Terraform modules. It's not meant to be run on production in this form.
 
 ## Topology and resources

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -1,8 +1,7 @@
-<!-- BEGIN_TF_DOCS -->
 ---
-short\_title: Standalone VM-Series Deployment
+short_title: Standalone VM-Series Deployment
 type: example
-show\_in\_hub: false
+show_in_hub: false
 ---
 # Palo Alto Networks Next Generation deployment example
 
@@ -11,8 +10,8 @@ An example of a Terraform module that deploys a Next Generation Firewall applian
 **NOTE:**
 
 - after the deployment firewall remains not licensed and not configured
-- this example contains some **files*- that **can contain sensitive data**, namely the `TFVARS` file can contain bootstrap\_options
-  properties in `var.vmseries` definition. Keep in mind that **this code*- is **only an example**. It's main purpose is to
+- this example contains some **files** that **can contain sensitive data**, namely the `TFVARS` file can contain bootstrap_options
+  properties in `var.vmseries` definition. Keep in mind that **this code** is **only an example**. It's main purpose is to
   introduce the Terraform modules. It's not meant to be run on production in this form.
 
 ## Topology and resources
@@ -113,7 +112,40 @@ To remove the deployed infrastructure run:
 terraform destroy
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `random`
+- `azurerm`
+- `local`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vnet_peering` | - | ../../modules/vnet_peering | 
+`natgw` | - | ../../modules/natgw | 
+`load_balancer` | - | ../../modules/loadbalancer | 
+`appgw` | - | ../../modules/appgw | 
+`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
+`bootstrap` | - | ../../modules/bootstrap | 
+`vmseries` | - | ../../modules/vmseries | 
+`test_infrastructure` | - | ../../modules/test_infrastructure | 
+
+### Resources
+
+- `availability_set` (managed)
+- `resource_group` (managed)
+- `file` (managed)
+- `password` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -121,7 +153,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -138,7 +170,7 @@ Name | Type | Description
 [`vmseries`](#vmseries) | `map` | A map defining Azure Virtual Machines based on Palo Alto Networks Next Generation Firewall image.
 [`test_infrastructure`](#test_infrastructure) | `map` | A map defining test infrastructure including test VMs and Azure Bastion hosts.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -151,42 +183,7 @@ Name |  Description
 `bootstrap_storage_urls` | 
 `app_lb_frontend_ips` | IP Addresses of the load balancers.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `random`
-- `azurerm`
-- `local`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vnet_peering` | - | ../../modules/vnet_peering | 
-`natgw` | - | ../../modules/natgw | 
-`load_balancer` | - | ../../modules/loadbalancer | 
-`appgw` | - | ../../modules/appgw | 
-`ngfw_metrics` | - | ../../modules/ngfw_metrics | 
-`bootstrap` | - | ../../modules/bootstrap | 
-`vmseries` | - | ../../modules/vmseries | 
-`test_infrastructure` | - | ../../modules/test_infrastructure | 
-
-Resources used in this module:
-
-- `availability_set` (managed)
-- `resource_group` (managed)
-- `file` (managed)
-- `password` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -277,7 +274,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -1264,5 +1261,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Application Gateway Module for Azure
 
 A terraform module for deploying a Application Gateway v2 and its components required for the VM-Series firewalls in Azure.
@@ -810,7 +809,26 @@ appgws = {
 }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `application_gateway` (managed)
+- `public_ip` (managed)
+- `public_ip` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -823,7 +841,7 @@ Name | Type | Description
 [`listeners`](#listeners) | `map` | A map of listeners for the Application Gateway.
 [`rules`](#rules) | `map` | A map of rules for the Application Gateway.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -843,7 +861,7 @@ Name | Type | Description
 [`redirects`](#redirects) | `map` | A map of redirects for the Application Gateway.
 [`url_path_maps`](#url_path_maps) | `map` | A map of URL path maps for the Application Gateway.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -851,28 +869,7 @@ Name |  Description
 `public_domain_name` | Public domain name assigned to the Application Gateway.
 `backend_pool_id` | The identifier of the Application Gateway backend address pool.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `application_gateway` (managed)
-- `public_ip` (managed)
-- `public_ip` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -1018,7 +1015,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -1451,5 +1448,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Bootstrap Module for Azure
 
 A terraform module for deploying a storage account and the dependencies required to
@@ -126,16 +125,39 @@ be discovered and the remote file will be overwritten. This has some implication
 The module can calculate hashes for the existing files - any files that were present before Terraform run.
 
 If however you are creating some files on the fly (templating for instance) you have to provide the MD5 hashes yourself. For more
-details refer to the [var.file\_shares](#file\_shares) variable documentation.
+details refer to the [var.file_shares](#file_shares) variable documentation.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `storage_account` (managed)
+- `storage_account_network_rules` (managed)
+- `storage_share` (managed)
+- `storage_share_directory` (managed)
+- `storage_share_file` (managed)
+- `storage_account` (data)
+- `storage_share` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`name`](#name) | `string` | Name of the Storage Account.
 [`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -146,7 +168,7 @@ Name | Type | Description
 [`file_shares_configuration`](#file_shares_configuration) | `object` | A map defining common File Share setting.
 [`file_shares`](#file_shares) | `map` | Definition of File Shares.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -154,32 +176,7 @@ Name |  Description
 `storage_account_primary_access_key` | The primary access key for the Azure Storage Account. For either created or sourced
 `file_share_urls` | The File Shares' share URL used for bootstrap configuration.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `storage_account` (managed)
-- `storage_account_network_rules` (managed)
-- `storage_share` (managed)
-- `storage_share_directory` (managed)
-- `storage_share_file` (managed)
-- `storage_account` (data)
-- `storage_share` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -202,7 +199,7 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### region
 
@@ -387,5 +384,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Gateway Load Balancer Module for Azure
 
 A Terraform module for deploying a Gateway Load Balancer for VM-Series firewalls.
@@ -81,7 +80,27 @@ For more customized requirements, below extended definition of GWLB can be appli
   }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `lb` (managed)
+- `lb_backend_address_pool` (managed)
+- `lb_probe` (managed)
+- `lb_rule` (managed)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -90,7 +109,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
 [`frontend_ip`](#frontend_ip) | `object` | Frontend IP configuration of the Gateway Load Balancer.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -100,36 +119,14 @@ Name | Type | Description
 [`backends`](#backends) | `map` | Map with backend configurations for the Gateway Load Balancer.
 [`lb_rule`](#lb_rule) | `object` | Load balancing rule configuration.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `backend_pool_ids` | Backend pools' identifiers.
 `frontend_ip_config_id` | Frontend IP configuration identifier.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `lb` (managed)
-- `lb_backend_address_pool` (managed)
-- `lb_probe` (managed)
-- `lb_rule` (managed)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -181,7 +178,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -304,5 +301,3 @@ object({
 Default value: `map[name:lb_rule]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Load Balancer Module for Azure
 
 A Terraform module for deploying a Load Balancer for VM-Series firewalls.
@@ -83,49 +82,20 @@ module "lbe" {
 }
 ```
 
-## Module's Required Inputs
+## Reference
 
-Name | Type | Description
---- | --- | ---
-[`name`](#name) | `string` | The name of the Azure Load Balancer.
-[`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
-[`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
-[`backend_name`](#backend_name) | `string` | The name of the backend pool to create.
-[`frontend_ips`](#frontend_ips) | `map` | A map of objects describing Load Balancer Frontend IP configurations with respective inbound and outbound rules.
-
-## Module's Optional Inputs
-
-Name | Type | Description
---- | --- | ---
-[`tags`](#tags) | `map` | The map of tags to assign to all created resources.
-[`zones`](#zones) | `list` | Controls zones for Load Balancer's fronted IP configurations.
-[`health_probes`](#health_probes) | `map` | Backend's health probe definition.
-[`nsg_auto_rules_settings`](#nsg_auto_rules_settings) | `object` | Controls automatic creation of NSG rules for all defined inbound rules.
-
-## Module's Outputs
-
-Name |  Description
---- | ---
-`backend_pool_id` | The identifier of the backend pool.
-`frontend_ip_configs` | Map of IP addresses, one per each entry of `frontend_ips` input. Contains public IP address for the frontends that have it,
-private IP address otherwise.
-
-`health_probe` | The health probe object.
-
-## Module's Nameplate
-
-Requirements needed by this module:
+### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-Providers used in this module:
+### Providers
 
 - `azurerm`, version: ~> 3.98
 
 
 
-Resources used in this module:
+### Resources
 
 - `lb` (managed)
 - `lb_backend_address_pool` (managed)
@@ -136,9 +106,36 @@ Resources used in this module:
 - `public_ip` (managed)
 - `public_ip` (data)
 
-## Inputs/Outpus details
-
 ### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`name`](#name) | `string` | The name of the Azure Load Balancer.
+[`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
+[`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
+[`backend_name`](#backend_name) | `string` | The name of the backend pool to create.
+[`frontend_ips`](#frontend_ips) | `map` | A map of objects describing Load Balancer Frontend IP configurations with respective inbound and outbound rules.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`tags`](#tags) | `map` | The map of tags to assign to all created resources.
+[`zones`](#zones) | `list` | Controls zones for Load Balancer's fronted IP configurations.
+[`health_probes`](#health_probes) | `map` | Backend's health probe definition.
+[`nsg_auto_rules_settings`](#nsg_auto_rules_settings) | `object` | Controls automatic creation of NSG rules for all defined inbound rules.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`backend_pool_id` | The identifier of the backend pool.
+`frontend_ip_configs` | Map of IP addresses, one per each entry of `frontend_ips` input. Contains public IP address for the frontends that have it,
+private IP address otherwise.
+
+`health_probe` | The health probe object.
+
+### Required Inputs details
 
 #### name
 
@@ -332,7 +329,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -440,5 +437,3 @@ object({
 Default value: `&{}`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/name_templater/README.md
+++ b/modules/name_templater/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Name Templater module
 
 A module to generate resource name template.
@@ -51,7 +50,24 @@ vnet_name = format(module.name_templates.template, "transit")
 
 Following the values above the actual resource name would be `"a_prefix-rnd-crediblefrog-prd-transit-vnet"`.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `random`, version: ~> 3.5
+
+### Providers
+
+- `random`, version: ~> 3.5
+
+
+
+### Resources
+
+- `pet` (managed)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -59,38 +75,19 @@ Name | Type | Description
 [`name_prefix`](#name_prefix) | `string` | Prefix used in names for the resources.
 [`name_template`](#name_template) | `object` | A name template definition.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`abbreviations`](#abbreviations) | `map` | Map of abbreviations used for resources (placed in place of "__default__").
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `template` | A template string that can be used with `format` function to generate a resource name.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `random`, version: ~> 3.5
-
-Providers used in this module:
-
-- `random`, version: ~> 3.5
-
-
-
-Resources used in this module:
-
-- `pet` (managed)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_type
 
@@ -167,7 +164,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### abbreviations
 
@@ -181,5 +178,3 @@ Type: map(string)
 Default value: `map[application_gw:agw application_insights:appi availability_set:avail bastion:bas data_disk:disk file_share:share load_balancer:lb log_analytics_workspace:log managed_identity:id nat_gw:ng network_interface:nic nsg:nsg nsg_rule:nsgsr os_disk:osdisk public_ip:pip public_ip_prefix:ippre resource_group:rg route_table:rt service_endpoint:se storage_account:st subnet:snet udr:udr virtual_machine:vm virtual_machine_scale_set:vmss virtual_network_gateway:vgw vnet:vnet vnet_peering:peer]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # NAT Gateway module
 
 ## Purpose
@@ -39,47 +38,20 @@ module.vnet.subnet_ids["a_subnet_name"] }
 This will create a NAT Gateway in with a single Public IP in a zone chosen
 by Azure.
 
-## Module's Required Inputs
+## Reference
 
-Name | Type | Description
---- | --- | ---
-[`name`](#name) | `string` | Name of a NAT Gateway.
-[`resource_group_name`](#resource_group_name) | `string` | Name of a Resource Group hosting the NAT Gateway (either the existing one or the one that will be created).
-[`region`](#region) | `string` | Azure region.
-[`subnet_ids`](#subnet_ids) | `map` | A map of subnet IDs what will be bound with this NAT Gateway.
-
-## Module's Optional Inputs
-
-Name | Type | Description
---- | --- | ---
-[`tags`](#tags) | `map` | A map of tags that will be assigned to resources created by this module.
-[`create_natgw`](#create_natgw) | `bool` | Triggers creation of a NAT Gateway when set to `true`.
-[`zone`](#zone) | `string` | Controls whether the NAT Gateway will be bound to a specific zone or not.
-[`idle_timeout`](#idle_timeout) | `number` | Connection IDLE timeout in minutes (up to 120, defaults to Azure defaults).
-[`public_ip`](#public_ip) | `object` | A map defining a Public IP resource.
-[`public_ip_prefix`](#public_ip_prefix) | `object` | A map defining a Public IP Prefix resource.
-
-## Module's Outputs
-
-Name |  Description
---- | ---
-`natgw_pip` | Public IP associated with the NAT Gateway.
-`natgw_pip_prefix` | Public IP Prefix associated with the NAT Gateway.
-
-## Module's Nameplate
-
-Requirements needed by this module:
+### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-Providers used in this module:
+### Providers
 
 - `azurerm`, version: ~> 3.98
 
 
 
-Resources used in this module:
+### Resources
 
 - `nat_gateway` (managed)
 - `nat_gateway_public_ip_association` (managed)
@@ -91,9 +63,34 @@ Resources used in this module:
 - `public_ip` (data)
 - `public_ip_prefix` (data)
 
-## Inputs/Outpus details
-
 ### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`name`](#name) | `string` | Name of a NAT Gateway.
+[`resource_group_name`](#resource_group_name) | `string` | Name of a Resource Group hosting the NAT Gateway (either the existing one or the one that will be created).
+[`region`](#region) | `string` | Azure region.
+[`subnet_ids`](#subnet_ids) | `map` | A map of subnet IDs what will be bound with this NAT Gateway.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`tags`](#tags) | `map` | A map of tags that will be assigned to resources created by this module.
+[`create_natgw`](#create_natgw) | `bool` | Triggers creation of a NAT Gateway when set to `true`.
+[`zone`](#zone) | `string` | Controls whether the NAT Gateway will be bound to a specific zone or not.
+[`idle_timeout`](#idle_timeout) | `number` | Connection IDLE timeout in minutes (up to 120, defaults to Azure defaults).
+[`public_ip`](#public_ip) | `object` | A map defining a Public IP resource.
+[`public_ip_prefix`](#public_ip_prefix) | `object` | A map defining a Public IP Prefix resource.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`natgw_pip` | Public IP associated with the NAT Gateway.
+`natgw_pip_prefix` | Public IP Prefix associated with the NAT Gateway.
+
+### Required Inputs details
 
 #### name
 
@@ -130,7 +127,7 @@ Type: map(string)
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -293,5 +290,3 @@ object({
 Default value: `&{}`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/ngfw_metrics/README.md
+++ b/modules/ngfw_metrics/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Metrics Infrastructure Module for Azure
 
 A Terraform module deploying Azure Application Insights (Log Analytics Workspace mode).
@@ -55,7 +54,26 @@ module "ngfw_metrics" {
 }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `application_insights` (managed)
+- `log_analytics_workspace` (managed)
+- `log_analytics_workspace` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -64,7 +82,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
 [`application_insights`](#application_insights) | `map` | A map defining Application Insights instances.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -72,35 +90,14 @@ Name | Type | Description
 [`create_workspace`](#create_workspace) | `bool` | Controls creation or sourcing of a Log Analytics Workspace.
 [`log_analytics_workspace`](#log_analytics_workspace) | `object` | Configuration of the log analytics workspace.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `metrics_instrumentation_keys` | The Instrumentation Key of the Application Insights instances.
 `application_insights_ids` | An Azure ID of the Application Insights instances.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `application_insights` (managed)
-- `log_analytics_workspace` (managed)
-- `log_analytics_workspace` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -156,7 +153,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -206,5 +203,3 @@ object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Panorama Module for Azure
 
 A terraform module for deploying a working Panorama instance in Azure.
@@ -18,7 +17,29 @@ az vm image terms accept --publisher paloaltonetworks --offer panorama --plan by
 You can revoke the acceptance later with the `az vm image terms cancel` command.
 The acceptance applies to the entirety of your Azure Subscription.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `linux_virtual_machine` (managed)
+- `managed_disk` (managed)
+- `network_interface` (managed)
+- `public_ip` (managed)
+- `virtual_machine_data_disk_attachment` (managed)
+- `public_ip` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -30,14 +51,14 @@ Name | Type | Description
 [`virtual_machine`](#virtual_machine) | `object` | Firewall parameters configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interface specifications.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`logging_disks`](#logging_disks) | `map` |  A map of objects describing the additional disks configuration.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -45,31 +66,7 @@ Name |  Description
 
 `interfaces` | Map of VM-Series network interfaces. Keys are equal to var.interfaces `name` properties.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `linux_virtual_machine` (managed)
-- `managed_disk` (managed)
-- `network_interface` (managed)
-- `public_ip` (managed)
-- `virtual_machine_data_disk_attachment` (managed)
-- `public_ip` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -291,7 +288,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -350,5 +347,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Test Infrastructure Module for Azure
 
 A Terraform module for deploying a Test Infrastructure in Azure cloud, containing peered VNETs with test VMs serving as
@@ -9,7 +8,35 @@ hosts for secure access to the test VMs.
 
 For usage please refer to any reference architecture example.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../vnet | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet
+`vnet_peering` | - | ../vnet_peering | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet_peering
+`load_balancer` | - | ../loadbalancer | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/loadbalancer
+
+### Resources
+
+- `bastion_host` (managed)
+- `linux_virtual_machine` (managed)
+- `network_interface` (managed)
+- `network_interface_backend_address_pool_association` (managed)
+- `public_ip` (managed)
+- `resource_group` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -20,7 +47,7 @@ Name | Type | Description
 [`spoke_vms`](#spoke_vms) | `map` | A map defining spoke VMs for testing.
 [`bastions`](#bastions) | `map` | A map containing Azure Bastion definition.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -28,7 +55,7 @@ Name | Type | Description
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`load_balancers`](#load_balancers) | `map` | A map containing configuration for all (both private and public) Load Balancers.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -37,37 +64,7 @@ Name |  Description
 private IP address otherwise.
 
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../vnet | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet
-`vnet_peering` | - | ../vnet_peering | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/vnet_peering
-`load_balancer` | - | ../loadbalancer | https://registry.terraform.io/modules/PaloAltoNetworks/swfw-modules/azurerm/latest/submodules/loadbalancer
-
-Resources used in this module:
-
-- `bastion_host` (managed)
-- `linux_virtual_machine` (managed)
-- `network_interface` (managed)
-- `network_interface_backend_address_pool_association` (managed)
-- `public_ip` (managed)
-- `resource_group` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -267,7 +264,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### create_resource_group
 
@@ -390,5 +387,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks Virtual Network Gateway Module for Azure
 
 A terraform module for deploying a VNG (Virtual Network Gateway) and its components required for the VM-Series firewalls in Azure.
@@ -313,7 +312,28 @@ variable "virtual_network_gateways" {
 }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `local_network_gateway` (managed)
+- `public_ip` (managed)
+- `virtual_network_gateway` (managed)
+- `virtual_network_gateway_connection` (managed)
+- `public_ip` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -324,7 +344,7 @@ Name | Type | Description
 [`instance_settings`](#instance_settings) | `object` | A map containing the basic Virtual Network Gateway instance settings.
 [`ip_configurations`](#ip_configurations) | `object` | A map defining the Public IPs used by the Virtual Network Gateway.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -338,37 +358,14 @@ Name | Type | Description
 [`local_network_gateways`](#local_network_gateways) | `map` | Map of local network gateways and their connections.
 [`vpn_clients`](#vpn_clients) | `map` | VPN client configurations (IPSec point-to-site connections).
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `public_ip` | Public IP addresses for Virtual Network Gateway
 `ipsec_policy` | IPsec policy used for Virtual Network Gateway connection
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `local_network_gateway` (managed)
-- `public_ip` (managed)
-- `virtual_network_gateway` (managed)
-- `virtual_network_gateway_connection` (managed)
-- `public_ip` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -517,7 +514,7 @@ object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -788,5 +785,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks VM-Series Module for Azure
 
 A Terraform module for deploying a VM-Series firewall in Azure cloud.
@@ -32,7 +31,28 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
    avzone   = null
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `linux_virtual_machine` (managed)
+- `network_interface` (managed)
+- `network_interface_backend_address_pool_association` (managed)
+- `public_ip` (managed)
+- `public_ip` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -44,13 +64,13 @@ Name | Type | Description
 [`virtual_machine`](#virtual_machine) | `object` | Firewall parameters configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interface specifications.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -60,30 +80,7 @@ Name |  Description
 `principal_id` | The ID of Azure Service Principal of the created VM-Series. Usable only if `identity_type` contains SystemAssigned.
 
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `linux_virtual_machine` (managed)
-- `network_interface` (managed)
-- `network_interface_backend_address_pool_association` (managed)
-- `public_ip` (managed)
-- `public_ip` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -328,7 +325,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -339,5 +336,3 @@ Type: map(string)
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks VMSS Module for Azure
 
 A terraform module for deploying a Scale Set based on Next Generation Firewalls in Azure.
@@ -40,11 +39,11 @@ autoscaling. This is a suggested way of setting up scaling rules as these metric
 
 This however requires some additional steps:
 
-- deploy the [`ngfw_metrics`](../ngfw\_metrics/README.md) module, this module outputs two properties:
+- deploy the [`ngfw_metrics`](../ngfw_metrics/README.md) module, this module outputs two properties:
   - `application_insights_ids` - a map of IDs of the deployed Application Insights instances
   - `metrics_instrumentation_keys` - a map of instrumentation keys for the deployed Application Insights instances
 - configure this module with the ID of the desired Application Insights instance, use the
-  [`var.autoscaling_configuration.application_insights_id`](#autoscaling\_configuration) property
+  [`var.autoscaling_configuration.application_insights_id`](#autoscaling_configuration) property
 - depending on the bootstrap method you use, configure the PAN-OS VM-Series plugins with the metrics instrumentation key
   belonging to the Application Insights instance of your choice.
 
@@ -99,7 +98,28 @@ module "vmss" {
 }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`ptd_time` | - | ./dt_string_converter | 
+
+### Resources
+
+- `linux_virtual_machine_scale_set` (managed)
+- `monitor_autoscale_setting` (managed)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -110,7 +130,7 @@ Name | Type | Description
 [`image`](#image) | `object` | Basic Azure VM configuration.
 [`interfaces`](#interfaces) | `list` | List of the network interfaces specifications.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -119,7 +139,7 @@ Name | Type | Description
 [`autoscaling_configuration`](#autoscaling_configuration) | `object` | Autoscaling configuration common to all policies.
 [`autoscaling_profiles`](#autoscaling_profiles) | `list` | A list defining autoscaling profiles.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -127,30 +147,7 @@ Name |  Description
 `username` | Firewall admin account name.
 `password` | Firewall admin password
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`ptd_time` | - | ./dt_string_converter | 
-
-Resources used in this module:
-
-- `linux_virtual_machine_scale_set` (managed)
-- `monitor_autoscale_setting` (managed)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### name
 
@@ -311,7 +308,7 @@ list(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -625,5 +622,3 @@ list(object({
 Default value: `[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/vmss/dt_string_converter/README.md
+++ b/modules/vmss/dt_string_converter/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Date/Time string representation converted
 
 This is a very simple module used solely to convert time in minutes to a string representation required by the
@@ -7,7 +6,17 @@ Azure Scale Set's autoscaling metrics rules.
 It's a sub module of the `vmss` module created to deduplicate code required to perform the conversion between
 two formats. It was not designed to be used outside of the `vmss` module.
 
-## Module's Required Inputs
+## Reference
+
+
+
+
+
+
+
+
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -15,25 +24,13 @@ Name | Type | Description
 
 
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `dt_string` | Azure string time representation.
 
-## Module's Nameplate
-
-
-
-
-
-
-
-
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### time
 
@@ -42,5 +39,3 @@ The time value in minutes to be converted to string representation.
 Type: number
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks VNet Module for Azure
 
 A Terraform module for deploying a Virtual Network and its components required for the VM-Series firewalls in Azure.
@@ -122,51 +121,20 @@ This module is designed to work in several *modes* depending on which variables 
   }
   ```
 
-## Module's Required Inputs
+## Reference
 
-Name | Type | Description
---- | --- | ---
-[`name`](#name) | `string` | The name of the Azure Virtual Network.
-[`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
-[`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
-
-## Module's Optional Inputs
-
-Name | Type | Description
---- | --- | ---
-[`tags`](#tags) | `map` | The map of tags to assign to all created resources.
-[`create_virtual_network`](#create_virtual_network) | `bool` | Controls Virtual Network creation.
-[`address_space`](#address_space) | `list` | The address space used by the virtual network.
-[`network_security_groups`](#network_security_groups) | `map` | Map of objects describing Network Security Groups.
-[`route_tables`](#route_tables) | `map` | Map of objects describing a Route Tables.
-[`create_subnets`](#create_subnets) | `bool` | Controls subnet creation.
-[`subnets`](#subnets) | `map` | Map of objects describing subnets to manage.
-
-## Module's Outputs
-
-Name |  Description
---- | ---
-`virtual_network_id` | The identifier of the created or sourced Virtual Network.
-`vnet_cidr` | VNET address space.
-`subnet_ids` | The identifiers of the created or sourced Subnets.
-`subnet_cidrs` | Subnet CIDRs (sourced or created).
-`network_security_group_ids` | The identifiers of the created Network Security Groups.
-`route_table_ids` | The identifiers of the created Route Tables.
-
-## Module's Nameplate
-
-Requirements needed by this module:
+### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
 - `azurerm`, version: ~> 3.98
 
-Providers used in this module:
+### Providers
 
 - `azurerm`, version: ~> 3.98
 
 
 
-Resources used in this module:
+### Resources
 
 - `network_security_group` (managed)
 - `network_security_rule` (managed)
@@ -179,9 +147,38 @@ Resources used in this module:
 - `subnet` (data)
 - `virtual_network` (data)
 
-## Inputs/Outpus details
-
 ### Required Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`name`](#name) | `string` | The name of the Azure Virtual Network.
+[`resource_group_name`](#resource_group_name) | `string` | The name of the Resource Group to use.
+[`region`](#region) | `string` | The name of the Azure region to deploy the resources in.
+
+### Optional Inputs
+
+Name | Type | Description
+--- | --- | ---
+[`tags`](#tags) | `map` | The map of tags to assign to all created resources.
+[`create_virtual_network`](#create_virtual_network) | `bool` | Controls Virtual Network creation.
+[`address_space`](#address_space) | `list` | The address space used by the virtual network.
+[`network_security_groups`](#network_security_groups) | `map` | Map of objects describing Network Security Groups.
+[`route_tables`](#route_tables) | `map` | Map of objects describing a Route Tables.
+[`create_subnets`](#create_subnets) | `bool` | Controls subnet creation.
+[`subnets`](#subnets) | `map` | Map of objects describing subnets to manage.
+
+### Outputs
+
+Name |  Description
+--- | ---
+`virtual_network_id` | The identifier of the created or sourced Virtual Network.
+`vnet_cidr` | VNET address space.
+`subnet_ids` | The identifiers of the created or sourced Subnets.
+`subnet_cidrs` | Subnet CIDRs (sourced or created).
+`network_security_group_ids` | The identifiers of the created Network Security Groups.
+`route_table_ids` | The identifiers of the created Route Tables.
+
+### Required Inputs details
 
 #### name
 
@@ -207,7 +204,7 @@ Type: string
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -513,5 +510,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/modules/vnet_peering/README.md
+++ b/modules/vnet_peering/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 # Palo Alto Networks VNet Peering Module for Azure
 
 A terraform module for deploying a Virtual Network Peering and its components required for the VM-Series firewalls in Azure.
@@ -21,7 +20,27 @@ remote_peer_config = {
 }
 ```
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+- `azurerm`, version: ~> 3.98
+
+### Providers
+
+- `azurerm`, version: ~> 3.98
+
+
+
+### Resources
+
+- `virtual_network_peering` (managed)
+- `virtual_network_peering` (managed)
+- `virtual_network` (data)
+- `virtual_network` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -30,7 +49,7 @@ Name | Type | Description
 
 
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
@@ -39,29 +58,7 @@ Name |  Description
 `local_peering_id` | The ID of the local VNET peering.
 `remote_peering_id` | The ID of the remote VNET peering.
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
-
-Providers used in this module:
-
-- `azurerm`, version: ~> 3.98
-
-
-
-Resources used in this module:
-
-- `virtual_network_peering` (managed)
-- `virtual_network_peering` (managed)
-- `virtual_network` (data)
-- `virtual_network` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### local_peer_config
 
@@ -130,5 +127,3 @@ object({
 
 
 <sup>[back to list](#modules-required-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/tests/appgw/README.md
+++ b/tests/appgw/README.md
@@ -1,11 +1,32 @@
-<!-- BEGIN_TF_DOCS -->
 # APP GW module sample
 
 A sample of using a APP GW module with the new variables layout and usage of `optional` keyword.
 
 The `README` is also in new, document-style format.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `azurerm`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`appgw` | - | ../../modules/appgw | 
+
+### Resources
+
+- `public_ip` (managed)
+- `resource_group` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -14,7 +35,7 @@ Name | Type | Description
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 [`appgws`](#appgws) | `map` | A map defining all Application Gateways in the current deployment.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -24,31 +45,7 @@ Name | Type | Description
 
 
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `azurerm`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`appgw` | - | ../../modules/appgw | 
-
-Resources used in this module:
-
-- `public_ip` (managed)
-- `resource_group` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### region
 
@@ -312,7 +309,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### tags
 
@@ -358,5 +355,3 @@ Type: bool
 Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->

--- a/tests/virtual_network_gateway/README.md
+++ b/tests/virtual_network_gateway/README.md
@@ -1,11 +1,31 @@
-<!-- BEGIN_TF_DOCS -->
 # VNG module sample
 
 A sample of using a VNG module with the new variables layout and usage of `optional` keyword.
 
 The `README` is also in new, document-style format.
 
-## Module's Required Inputs
+## Reference
+
+### Requirements
+
+- `terraform`, version: >= 1.5, < 2.0
+
+### Providers
+
+- `azurerm`
+
+### Modules
+Name | Version | Source | Description
+--- | --- | --- | ---
+`vnet` | - | ../../modules/vnet | 
+`vng` | - | ../../modules/virtual_network_gateway | 
+
+### Resources
+
+- `resource_group` (managed)
+- `resource_group` (data)
+
+### Required Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -13,7 +33,7 @@ Name | Type | Description
 [`region`](#region) | `string` | The Azure region to use.
 [`vnets`](#vnets) | `map` | A map defining VNETs.
 
-## Module's Optional Inputs
+### Optional Inputs
 
 Name | Type | Description
 --- | --- | ---
@@ -22,37 +42,14 @@ Name | Type | Description
 [`tags`](#tags) | `map` | Map of tags to assign to the created resources.
 [`virtual_network_gateways`](#virtual_network_gateways) | `map` | Map of Virtual Network Gateways to create.
 
-## Module's Outputs
+### Outputs
 
 Name |  Description
 --- | ---
 `vng_public_ips` | IP Addresses of the VNGs.
 `vng_ipsec_policy` | IPsec policy used for Virtual Network Gateway connection
 
-## Module's Nameplate
-
-Requirements needed by this module:
-
-- `terraform`, version: >= 1.5, < 2.0
-
-Providers used in this module:
-
-- `azurerm`
-
-Modules used in this module:
-Name | Version | Source | Description
---- | --- | --- | ---
-`vnet` | - | ../../modules/vnet | 
-`vng` | - | ../../modules/virtual_network_gateway | 
-
-Resources used in this module:
-
-- `resource_group` (managed)
-- `resource_group` (data)
-
-## Inputs/Outpus details
-
-### Required Inputs
+### Required Inputs details
 
 #### resource_group_name
 
@@ -143,7 +140,7 @@ map(object({
 
 <sup>[back to list](#modules-required-inputs)</sup>
 
-### Optional Inputs
+### Optional Inputs details
 
 #### name_prefix
 
@@ -295,5 +292,3 @@ map(object({
 Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
-
-<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
* Trigger for `hub_sync.yml` workflow got changed to **schedule**, weekly 2hrs after Release workflow.
* Configuration files for `terraform-docs` were modified to get rid of `<!-- BEGIN_TF_DOCS -->` & `<!-- END_TF_DOCS -->` markers and escape characters before `_`.
* The header structure in README files got modified.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Workflow `hub_sync.yml` wasn't triggered on release as configured. Turned out to be an issue in `semantic-release` repo (https://github.com/semantic-release/github/issues/264#issuecomment-617339717).
* The `terraform-docs` didn't generate the **frontmatter** properly for examples README files.
* README file structure wasn't compliant with **pan.dev** concept.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `pre-commit` on local machine.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
