### PR TITLE
docs: Add tr closing tag to the table in VNG module

### DIFF
--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -429,6 +429,7 @@ table below for details on available combinations:
     <td rowspan="11">Vpn</td>
     <td rowspan="3">Generation1</td>
     <td>Basic</td>
+  </tr>
   <tr><td>VpnGw1</td></tr>
   <tr><td>VpnGw1AZ</td></tr>
   <tr>

--- a/modules/virtual_network_gateway/variables.tf
+++ b/modules/virtual_network_gateway/variables.tf
@@ -78,6 +78,7 @@ variable "instance_settings" {
       <td rowspan="11">Vpn</td>
       <td rowspan="3">Generation1</td>
       <td>Basic</td>
+    </tr>
     <tr><td>VpnGw1</td></tr>
     <tr><td>VpnGw1AZ</td></tr>
     <tr>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds a **tr** closing tag to the table in one of the VNG module's variable description.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`pan.dev` CI failed to generate the docs due to lack of `</tr>` in a table in VNG module's README file.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
