### PR TITLE
fix: Fix sourcing an LB PIP from another RG

### DIFF
--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -48,7 +48,7 @@ data "azurerm_public_ip" "this" {
   for_each = { for k, v in var.frontend_ips : k => v if !v.create_public_ip && v.public_ip_name != null }
 
   name                = each.value.public_ip_name
-  resource_group_name = coalesce(each.value.public_ip_resource_group, var.resource_group_name)
+  resource_group_name = coalesce(each.value.public_ip_resource_group_name, var.resource_group_name)
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

There was a typo in a `public_ip_resource_group_name` variable name within data source block in `main.tf` of the `loadbalancer` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was impossible to source a Public IP resource for the Load Balancer from another Resource Group.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally from my workstation.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
