### PR TITLE
fix: Allow null for zones var in loadbalancer module

### DIFF
--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -36,7 +36,6 @@ variable "zones" {
   available in a region (typically 3): `["1","2","3"]`.
   EOF
   default     = ["1", "2", "3"]
-  nullable    = false
   type        = list(string)
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR removes `nullable = false` statement from `zones` variable in `loadbalancer` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was impossible to set a `null` value for `zones` variable, which prevented the non-zonal deployment (and not all regions support availability zones).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally on my workstation.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
