### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in vmss module

### DIFF
--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -985,12 +985,12 @@ map(object({
       name                           = string
       subnet_key                     = string
       create_public_ip               = optional(bool)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
       pip_domain_name_label          = optional(string)
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -930,8 +930,8 @@ The basic Scale Set configuration properties are as follows:
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in the
                                 `var.appgws`, network interface that has this property defined will be added to the Application
                                 Gateways's backend pool.
-  - `pip_domain_name_label`   - (`string`, optional, defaults to `null`) prefix which should be used for the Domain Name Label
-                                for each VM instance.
+
+  For details on all properties refer to [module's documentation](../../modules/vmss/README.md#interfaces).
 
 - `autoscaling_profiles`      - (`list`, optional, defaults to `[]`) a list of autoscaling profiles, for details on available
                                 properties please refer to
@@ -982,12 +982,15 @@ map(object({
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                    = string
-      subnet_key              = string
-      create_public_ip        = optional(bool)
-      load_balancer_key       = optional(string)
-      application_gateway_key = optional(string)
-      pip_domain_name_label   = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/common_vmseries_and_autoscale/main.tf
+++ b/examples/common_vmseries_and_autoscale/main.tf
@@ -265,12 +265,15 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name                   = v.name
-      subnet_id              = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-      create_public_ip       = v.create_public_ip
-      pip_domain_name_label  = v.pip_domain_name_label
-      lb_backend_pool_ids    = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
-      appgw_backend_pool_ids = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
+      name                           = v.name
+      subnet_id                      = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+      create_public_ip               = v.create_public_ip
+      pip_domain_name_label          = v.pip_domain_name_label
+      pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+      pip_prefix_name                = v.pip_prefix_name
+      pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+      lb_backend_pool_ids            = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
+      appgw_backend_pool_ids         = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
     }
   ]
 

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -592,8 +592,8 @@ variable "scale_sets" {
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in the
                                   `var.appgws`, network interface that has this property defined will be added to the Application
                                   Gateways's backend pool.
-    - `pip_domain_name_label`   - (`string`, optional, defaults to `null`) prefix which should be used for the Domain Name Label
-                                  for each VM instance.
+
+    For details on all properties refer to [module's documentation](../../modules/vmss/README.md#interfaces).
 
   - `autoscaling_profiles`      - (`list`, optional, defaults to `[]`) a list of autoscaling profiles, for details on available
                                   properties please refer to
@@ -642,12 +642,15 @@ variable "scale_sets" {
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                    = string
-      subnet_key              = string
-      create_public_ip        = optional(bool)
-      load_balancer_key       = optional(string)
-      application_gateway_key = optional(string)
-      pip_domain_name_label   = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -645,12 +645,12 @@ variable "scale_sets" {
       name                           = string
       subnet_key                     = string
       create_public_ip               = optional(bool)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
       pip_domain_name_label          = optional(string)
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -924,8 +924,8 @@ The basic Scale Set configuration properties are as follows:
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in the
                                 `var.appgws`, network interface that has this property defined will be added to the Application
                                 Gateways's backend pool.
-  - `pip_domain_name_label`   - (`string`, optional, defaults to `null`) prefix which should be used for the Domain Name Label
-                                for each VM instance.
+
+  For details on all properties refer to [module's documentation](../../modules/vmss/README.md#interfaces).
 
 - `autoscaling_profiles`      - (`list`, optional, defaults to `[]`) a list of autoscaling profiles, for details on available
                                 properties please refer to
@@ -976,12 +976,15 @@ map(object({
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                    = string
-      subnet_key              = string
-      create_public_ip        = optional(bool)
-      load_balancer_key       = optional(string)
-      application_gateway_key = optional(string)
-      pip_domain_name_label   = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -979,12 +979,12 @@ map(object({
       name                           = string
       subnet_key                     = string
       create_public_ip               = optional(bool)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
       pip_domain_name_label          = optional(string)
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/dedicated_vmseries_and_autoscale/main.tf
+++ b/examples/dedicated_vmseries_and_autoscale/main.tf
@@ -265,12 +265,15 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name                   = v.name
-      subnet_id              = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-      create_public_ip       = v.create_public_ip
-      pip_domain_name_label  = v.pip_domain_name_label
-      lb_backend_pool_ids    = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
-      appgw_backend_pool_ids = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
+      name                           = v.name
+      subnet_id                      = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+      create_public_ip               = v.create_public_ip
+      pip_domain_name_label          = v.pip_domain_name_label
+      pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+      pip_prefix_name                = v.pip_prefix_name
+      pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+      lb_backend_pool_ids            = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
+      appgw_backend_pool_ids         = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
     }
   ]
 

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -592,8 +592,8 @@ variable "scale_sets" {
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in the
                                   `var.appgws`, network interface that has this property defined will be added to the Application
                                   Gateways's backend pool.
-    - `pip_domain_name_label`   - (`string`, optional, defaults to `null`) prefix which should be used for the Domain Name Label
-                                  for each VM instance.
+
+    For details on all properties refer to [module's documentation](../../modules/vmss/README.md#interfaces).
 
   - `autoscaling_profiles`      - (`list`, optional, defaults to `[]`) a list of autoscaling profiles, for details on available
                                   properties please refer to
@@ -642,12 +642,15 @@ variable "scale_sets" {
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                    = string
-      subnet_key              = string
-      create_public_ip        = optional(bool)
-      load_balancer_key       = optional(string)
-      application_gateway_key = optional(string)
-      pip_domain_name_label   = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -645,12 +645,12 @@ variable "scale_sets" {
       name                           = string
       subnet_key                     = string
       create_public_ip               = optional(bool)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
       pip_domain_name_label          = optional(string)
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -118,6 +118,7 @@ Name | Version | Source | Description
 
 - `linux_virtual_machine_scale_set` (managed)
 - `monitor_autoscale_setting` (managed)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -260,15 +261,21 @@ Interfaces will be attached to VM in the order you define here, therefore:
   
 Following configuration options are available:
 
-- `name`                   - (`string`, required) the interface name.
-- `subnet_id`              - (`string`, required) ID of an existing subnet to create the interface in.
-- `create_public_ip`       - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-- `lb_backend_pool_ids`    - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer backend pools
-                             to associate the interface with.
-- `appgw_backend_pool_ids` - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend pools
-                             to associate the interface with.
-- `pip_domain_name_label`  - (`string`, optional, defaults to `null`) the IP Prefix which should be used for the Domain Name
-                             Label for each Virtual Machine Instance.
+- `name`                           - (`string`, required) the interface name.
+- `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+- `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+- `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
+                                     backend pools to associate the interface with.
+- `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
+                                     pools to associate the interface with.
+- `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                     Name Label for each Virtual Machine Instance.
+- `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                     IP Address, possible values are in the range from 4 to 32.
+- `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                     Addresses should be allocated.
+- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                     existing Public IP Prefix resource. 
 
 Example:
 
@@ -296,12 +303,15 @@ Type:
 
 ```hcl
 list(object({
-    name                   = string
-    subnet_id              = string
-    create_public_ip       = optional(bool, false)
-    lb_backend_pool_ids    = optional(list(string), [])
-    appgw_backend_pool_ids = optional(list(string), [])
-    pip_domain_name_label  = optional(string)
+    name                           = string
+    subnet_id                      = string
+    create_public_ip               = optional(bool, false)
+    lb_backend_pool_ids            = optional(list(string), [])
+    appgw_backend_pool_ids         = optional(list(string), [])
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
   }))
 ```
 

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -264,10 +264,6 @@ Following configuration options are available:
 - `name`                           - (`string`, required) the interface name.
 - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
 - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-- `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
-                                     backend pools to associate the interface with.
-- `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
-                                     pools to associate the interface with.
 - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
                                      Name Label for each Virtual Machine Instance.
 - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
@@ -275,7 +271,11 @@ Following configuration options are available:
 - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
                                      Addresses should be allocated.
 - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                     existing Public IP Prefix resource. 
+                                     existing Public IP Prefix resource.
+- `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
+                                     backend pools to associate the interface with.
+- `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
+                                     pools to associate the interface with.
 
 Example:
 
@@ -306,12 +306,12 @@ list(object({
     name                           = string
     subnet_id                      = string
     create_public_ip               = optional(bool, false)
-    lb_backend_pool_ids            = optional(list(string), [])
-    appgw_backend_pool_ids         = optional(list(string), [])
     pip_domain_name_label          = optional(string)
     pip_idle_timeout_in_minutes    = optional(number)
     pip_prefix_name                = optional(string)
     pip_prefix_resource_group_name = optional(string)
+    lb_backend_pool_ids            = optional(list(string), [])
+    appgw_backend_pool_ids         = optional(list(string), [])
   }))
 ```
 

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -4,7 +4,7 @@ locals {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
 data "azurerm_public_ip_prefix" "this" {
-  for_each = { for pip in var.interfaces : pip.name => pip if pip.pip_prefix_name != null }
+  for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
 
   name                = each.value.pip_prefix_name
   resource_group_name = coalesce(each.value.pip_prefix_resource_group_name, var.resource_group_name)

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
-data "azurerm_public_ip_prefix" "this" {
+data "azurerm_public_ip_prefix" "allocate" {
   for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
 
   name                = each.value.pip_prefix_name
@@ -103,7 +103,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
             version                 = "IPv4"
             domain_name_label       = nic.value.pip_domain_name_label
             idle_timeout_in_minutes = nic.value.pip_idle_timeout_in_minutes
-            public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[nic.value.name].id, null)
+            public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[nic.value.name].id, null)
           }
         }
       }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -222,10 +222,6 @@ variable "interfaces" {
   - `name`                           - (`string`, required) the interface name.
   - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
   - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-  - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
-                                       backend pools to associate the interface with.
-  - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
-                                       pools to associate the interface with.
   - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
                                        Name Label for each Virtual Machine Instance.
   - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
@@ -233,7 +229,11 @@ variable "interfaces" {
   - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
                                        Addresses should be allocated.
   - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                       existing Public IP Prefix resource. 
+                                       existing Public IP Prefix resource.
+  - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
+                                       backend pools to associate the interface with.
+  - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
+                                       pools to associate the interface with.
 
   Example:
 
@@ -260,12 +260,12 @@ variable "interfaces" {
     name                           = string
     subnet_id                      = string
     create_public_ip               = optional(bool, false)
-    lb_backend_pool_ids            = optional(list(string), [])
-    appgw_backend_pool_ids         = optional(list(string), [])
     pip_domain_name_label          = optional(string)
     pip_idle_timeout_in_minutes    = optional(number)
     pip_prefix_name                = optional(string)
     pip_prefix_resource_group_name = optional(string)
+    lb_backend_pool_ids            = optional(list(string), [])
+    appgw_backend_pool_ids         = optional(list(string), [])
   }))
   validation { # lb_backend_pool_ids & appgw_backend_pool_ids
     condition     = length(var.interfaces[0].lb_backend_pool_ids) == 0 && length(var.interfaces[0].appgw_backend_pool_ids) == 0

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -275,8 +275,8 @@ variable "interfaces" {
   }
   validation { # pip_idle_timeout_in_minutes
     condition = alltrue([
-      for pip in var.interfaces : (pip.pip_idle_timeout_in_minutes >= 4 && pip.pip_idle_timeout_in_minutes <= 32)
-    if pip.pip_idle_timeout_in_minutes != null])
+      for v in var.interfaces : (v.pip_idle_timeout_in_minutes >= 4 && v.pip_idle_timeout_in_minutes <= 32)
+    if v.pip_idle_timeout_in_minutes != null])
     error_message = <<-EOF
     The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -219,15 +219,21 @@ variable "interfaces" {
   
   Following configuration options are available:
 
-  - `name`                   - (`string`, required) the interface name.
-  - `subnet_id`              - (`string`, required) ID of an existing subnet to create the interface in.
-  - `create_public_ip`       - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-  - `lb_backend_pool_ids`    - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer backend pools
-                               to associate the interface with.
-  - `appgw_backend_pool_ids` - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend pools
-                               to associate the interface with.
-  - `pip_domain_name_label`  - (`string`, optional, defaults to `null`) the IP Prefix which should be used for the Domain Name
-                               Label for each Virtual Machine Instance.
+  - `name`                           - (`string`, required) the interface name.
+  - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+  - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+  - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
+                                       backend pools to associate the interface with.
+  - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
+                                       pools to associate the interface with.
+  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                       Name Label for each Virtual Machine Instance.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                       IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                       Addresses should be allocated.
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                       existing Public IP Prefix resource. 
 
   Example:
 
@@ -251,17 +257,28 @@ variable "interfaces" {
   ```
   EOF
   type = list(object({
-    name                   = string
-    subnet_id              = string
-    create_public_ip       = optional(bool, false)
-    lb_backend_pool_ids    = optional(list(string), [])
-    appgw_backend_pool_ids = optional(list(string), [])
-    pip_domain_name_label  = optional(string)
+    name                           = string
+    subnet_id                      = string
+    create_public_ip               = optional(bool, false)
+    lb_backend_pool_ids            = optional(list(string), [])
+    appgw_backend_pool_ids         = optional(list(string), [])
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
   }))
   validation { # lb_backend_pool_ids & appgw_backend_pool_ids
     condition     = length(var.interfaces[0].lb_backend_pool_ids) == 0 && length(var.interfaces[0].appgw_backend_pool_ids) == 0
     error_message = <<-EOF
     The `lb_backend_pool_ids` and `appgw_backend_pool_ids` properties are not acceptable for the 1st (management) interface.
+    EOF
+  }
+  validation { # pip_idle_timeout_in_minutes
+    condition = alltrue([
+      for i in var.interfaces : (i.pip_idle_timeout_in_minutes >= 4 && i.pip_idle_timeout_in_minutes <= 32)
+    if i.pip_idle_timeout_in_minutes != null])
+    error_message = <<-EOF
+    The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF
   }
 }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -275,8 +275,8 @@ variable "interfaces" {
   }
   validation { # pip_idle_timeout_in_minutes
     condition = alltrue([
-      for i in var.interfaces : (i.pip_idle_timeout_in_minutes >= 4 && i.pip_idle_timeout_in_minutes <= 32)
-    if i.pip_idle_timeout_in_minutes != null])
+      for pip in var.interfaces : (pip.pip_idle_timeout_in_minutes >= 4 && pip.pip_idle_timeout_in_minutes <= 32)
+    if pip.pip_idle_timeout_in_minutes != null])
     error_message = <<-EOF
     The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IPs for the VMSS instances from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the interface object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.
#57 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the examples, testing different scenarios.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
