### PR TITLE
feat: Add VNet peering parameters support to test_infrastructure module

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1180,6 +1180,12 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering.  
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -1257,8 +1263,7 @@ map(object({
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -1276,7 +1281,8 @@ map(object({
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1292,6 +1298,18 @@ map(object({
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -456,6 +456,8 @@ module "test_infrastructure" {
     route_tables = { for kv, vv in v.route_tables : kv => merge(vv, {
       name = "${var.name_prefix}${vv.name}" })
     }
+    local_peer_config  = try(v.local_peer_config, {})
+    remote_peer_config = try(v.remote_peer_config, {})
   }) }
   load_balancers = { for k, v in each.value.load_balancers : k => merge(v, {
     name         = "${var.name_prefix}${v.name}"

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -891,6 +891,12 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the remote VNet peering.  
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -966,8 +972,7 @@ variable "test_infrastructure" {
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -985,7 +990,8 @@ variable "test_infrastructure" {
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1001,6 +1007,18 @@ variable "test_infrastructure" {
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -1041,13 +1041,13 @@ For details and defaults for available options please refer to the
 
 Following properties are supported:
 
-- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                              set to `false`, an existing Resource Group is sourced.
 - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
 - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                              properties are as follows:
 
-  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                 `false` will source an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                 a full resource name, including prefixes.
@@ -1061,9 +1061,15 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering. 
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
 - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                              The most basic properties are as follows:
 
@@ -1080,8 +1086,8 @@ Following properties are supported:
   - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                 will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                 [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                for available properties. 
-                                
+                                for available properties.
+
   Please note that in this example two additional properties are available:
 
     - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -1112,10 +1118,10 @@ Following properties are supported:
 
   For all properties and their default values see
   [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
 - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                              follows:
-                               
+
   - `name`       - (`string`, required) an Azure Bastion name.
   - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                    existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -1138,8 +1144,7 @@ map(object({
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -1157,7 +1162,8 @@ map(object({
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1173,6 +1179,18 @@ map(object({
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/common_vmseries_and_autoscale/main.tf
+++ b/examples/common_vmseries_and_autoscale/main.tf
@@ -317,6 +317,8 @@ module "test_infrastructure" {
     route_tables = { for kv, vv in v.route_tables : kv => merge(vv, {
       name = "${var.name_prefix}${vv.name}" })
     }
+    local_peer_config  = try(v.local_peer_config, {})
+    remote_peer_config = try(v.remote_peer_config, {})
   }) }
   load_balancers = { for k, v in each.value.load_balancers : k => merge(v, {
     name         = "${var.name_prefix}${v.name}"

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -698,13 +698,13 @@ variable "test_infrastructure" {
 
   Following properties are supported:
 
-  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                                set to `false`, an existing Resource Group is sourced.
   - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
   - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                                properties are as follows:
 
-    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                   `false` will source an existing VNET.
     - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                   a full resource name, including prefixes.
@@ -718,9 +718,15 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the remote VNet peering. 
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
   - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                                The most basic properties are as follows:
 
@@ -737,8 +743,8 @@ variable "test_infrastructure" {
     - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                   will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                   [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                  for available properties. 
-                                
+                                  for available properties.
+
     Please note that in this example two additional properties are available:
 
       - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -769,10 +775,10 @@ variable "test_infrastructure" {
 
     For all properties and their default values see
     [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
   - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                                follows:
-                               
+
     - `name`       - (`string`, required) an Azure Bastion name.
     - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                      existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -793,8 +799,7 @@ variable "test_infrastructure" {
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -812,7 +817,8 @@ variable "test_infrastructure" {
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -828,6 +834,18 @@ variable "test_infrastructure" {
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1164,13 +1164,13 @@ For details and defaults for available options please refer to the
 
 Following properties are supported:
 
-- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                              set to `false`, an existing Resource Group is sourced.
 - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
 - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                              properties are as follows:
 
-  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                 `false` will source an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                 a full resource name, including prefixes.
@@ -1184,9 +1184,15 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering.  
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
 - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                              The most basic properties are as follows:
 
@@ -1203,8 +1209,8 @@ Following properties are supported:
   - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                 will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                 [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                for available properties. 
-                                
+                                for available properties.
+
   Please note that in this example two additional properties are available:
 
     - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -1235,10 +1241,10 @@ Following properties are supported:
 
   For all properties and their default values see
   [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
 - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                              follows:
-                               
+
   - `name`       - (`string`, required) an Azure Bastion name.
   - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                    existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -1261,8 +1267,7 @@ map(object({
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -1280,7 +1285,8 @@ map(object({
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1296,6 +1302,18 @@ map(object({
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -456,6 +456,8 @@ module "test_infrastructure" {
     route_tables = { for kv, vv in v.route_tables : kv => merge(vv, {
       name = "${var.name_prefix}${vv.name}" })
     }
+    local_peer_config  = try(v.local_peer_config, {})
+    remote_peer_config = try(v.remote_peer_config, {})
   }) }
   load_balancers = { for k, v in each.value.load_balancers : k => merge(v, {
     name         = "${var.name_prefix}${v.name}"

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -871,13 +871,13 @@ variable "test_infrastructure" {
 
   Following properties are supported:
 
-  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                                set to `false`, an existing Resource Group is sourced.
   - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
   - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                                properties are as follows:
 
-    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                   `false` will source an existing VNET.
     - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                   a full resource name, including prefixes.
@@ -891,9 +891,15 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the remote VNet peering.  
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
   - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                                The most basic properties are as follows:
 
@@ -910,8 +916,8 @@ variable "test_infrastructure" {
     - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                   will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                   [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                  for available properties. 
-                                
+                                  for available properties.
+
     Please note that in this example two additional properties are available:
 
       - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -942,10 +948,10 @@ variable "test_infrastructure" {
 
     For all properties and their default values see
     [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
   - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                                follows:
-                               
+
     - `name`       - (`string`, required) an Azure Bastion name.
     - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                      existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -966,8 +972,7 @@ variable "test_infrastructure" {
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -985,7 +990,8 @@ variable "test_infrastructure" {
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1001,6 +1007,18 @@ variable "test_infrastructure" {
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -1035,13 +1035,13 @@ For details and defaults for available options please refer to the
 
 Following properties are supported:
 
-- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                              set to `false`, an existing Resource Group is sourced.
 - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
 - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                              properties are as follows:
 
-  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                 `false` will source an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                 a full resource name, including prefixes.
@@ -1055,9 +1055,15 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering. 
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
 - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                              The most basic properties are as follows:
 
@@ -1074,8 +1080,8 @@ Following properties are supported:
   - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                 will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                 [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                for available properties. 
-                                
+                                for available properties.
+
   Please note that in this example two additional properties are available:
 
     - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -1106,10 +1112,10 @@ Following properties are supported:
 
   For all properties and their default values see
   [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
 - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                              follows:
-                               
+
   - `name`       - (`string`, required) an Azure Bastion name.
   - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                    existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -1132,8 +1138,7 @@ map(object({
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -1151,7 +1156,8 @@ map(object({
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -1167,6 +1173,18 @@ map(object({
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/dedicated_vmseries_and_autoscale/main.tf
+++ b/examples/dedicated_vmseries_and_autoscale/main.tf
@@ -317,6 +317,8 @@ module "test_infrastructure" {
     route_tables = { for kv, vv in v.route_tables : kv => merge(vv, {
       name = "${var.name_prefix}${vv.name}" })
     }
+    local_peer_config  = try(v.local_peer_config, {})
+    remote_peer_config = try(v.remote_peer_config, {})
   }) }
   load_balancers = { for k, v in each.value.load_balancers : k => merge(v, {
     name         = "${var.name_prefix}${v.name}"

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -698,13 +698,13 @@ variable "test_infrastructure" {
 
   Following properties are supported:
 
-  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                                set to `false`, an existing Resource Group is sourced.
   - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
   - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                                properties are as follows:
 
-    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                   `false` will source an existing VNET.
     - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                   a full resource name, including prefixes.
@@ -718,9 +718,15 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the remote VNet peering. 
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
   - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                                The most basic properties are as follows:
 
@@ -737,8 +743,8 @@ variable "test_infrastructure" {
     - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                   will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                   [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                  for available properties. 
-                                
+                                  for available properties.
+
     Please note that in this example two additional properties are available:
 
       - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -769,10 +775,10 @@ variable "test_infrastructure" {
 
     For all properties and their default values see
     [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
   - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                                follows:
-                               
+
     - `name`       - (`string`, required) an Azure Bastion name.
     - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                      existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -793,8 +799,7 @@ variable "test_infrastructure" {
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -812,7 +817,8 @@ variable "test_infrastructure" {
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -828,6 +834,18 @@ variable "test_infrastructure" {
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -815,13 +815,13 @@ For details and defaults for available options please refer to the
 
 Following properties are supported:
 
-- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+- `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                              set to `false`, an existing Resource Group is sourced.
 - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
 - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                              properties are as follows:
 
-  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                 `false` will source an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                 a full resource name, including prefixes.
@@ -835,9 +835,15 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering. 
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
 - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                              The most basic properties are as follows:
 
@@ -854,8 +860,8 @@ Following properties are supported:
   - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                 will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                 [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                for available properties. 
-                                
+                                for available properties.
+
   Please note that in this example two additional properties are available:
 
     - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -886,10 +892,10 @@ Following properties are supported:
 
   For all properties and their default values see
   [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
 - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                              follows:
-                               
+
   - `name`       - (`string`, required) an Azure Bastion name.
   - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                    existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -912,8 +918,7 @@ map(object({
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -931,7 +936,8 @@ map(object({
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -947,6 +953,18 @@ map(object({
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/examples/gwlb_with_vmseries/main.tf
+++ b/examples/gwlb_with_vmseries/main.tf
@@ -337,6 +337,8 @@ module "test_infrastructure" {
     route_tables = { for kv, vv in v.route_tables : kv => merge(vv, {
       name = "${var.name_prefix}${vv.name}" })
     }
+    local_peer_config  = try(v.local_peer_config, {})
+    remote_peer_config = try(v.remote_peer_config, {})
   }) }
   load_balancers = { for k, v in each.value.load_balancers : k => merge(v, {
     name         = "${var.name_prefix}${v.name}"

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -597,13 +597,13 @@ variable "test_infrastructure" {
 
   Following properties are supported:
 
-  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When 
+  - `create_resource_group`  - (`bool`, optional, defaults to `true`) when set to `true`, a new Resource Group is created. When
                                set to `false`, an existing Resource Group is sourced.
   - `resource_group_name`    - (`string`, optional) name of the Resource Group to be created or sourced.
   - `vnets`                  - (`map`, required) a map defining VNETs and peerings for the test environment. The most basic
                                properties are as follows:
 
-    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, 
+    - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET,
                                   `false` will source an existing VNET.
     - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = `false` this should be
                                   a full resource name, including prefixes.
@@ -617,9 +617,15 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                  `use_remote_gateways` parameters on the remote VNet peering. 
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
-  
+
   - `load_balancers`         - (`map`, optional) a map containing configuration for all (both private and public) Load Balancers.
                                The most basic properties are as follows:
 
@@ -636,8 +642,8 @@ variable "test_infrastructure" {
     - `nsg_auto_rules_settings` - (`map`, optional, defaults to `null`) a map defining a location of an existing NSG rule that
                                   will be populated with `Allow` rules for each load balancing rule (`in_rules`), please refer to
                                   [loadbalancer module documentation](../../modules/loadbalancer/README.md#nsg_auto_rules_settings)
-                                  for available properties. 
-                                
+                                  for available properties.
+
     Please note that in this example two additional properties are available:
 
       - `nsg_vnet_key` - (`string`, optional, mutually exclusive with `nsg_name`) a key pointing to a VNET definition in the
@@ -668,10 +674,10 @@ variable "test_infrastructure" {
 
     For all properties and their default values see
     [module's documentation](../../modules/test_infrastructure/README.md#test_vms).
-  
+
   - `bastions`               - (`map`, required) a map containing Azure Bastion definitions. The most basic properties are as
                                follows:
-                               
+
     - `name`       - (`string`, required) an Azure Bastion name.
     - `vnet_key`   - (`string`, required) a key describing a VNET defined in `vnets` property. This VNET should already have an
                      existing subnet called `AzureBastionSubnet` (the name is hardcoded by Microsoft).
@@ -692,8 +698,7 @@ variable "test_infrastructure" {
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({
-        name                          = string
-        disable_bgp_route_propagation = optional(bool)
+        name = string
         rules = optional(map(object({
           name                         = string
           priority                     = number
@@ -711,7 +716,8 @@ variable "test_infrastructure" {
         })), {})
       })), {})
       route_tables = optional(map(object({
-        name = string
+        name                          = string
+        disable_bgp_route_propagation = optional(bool)
         routes = map(object({
           name                = string
           address_prefix      = string
@@ -727,6 +733,18 @@ variable "test_infrastructure" {
         route_table_key                 = optional(string)
         enable_storage_service_endpoint = optional(bool, false)
       })), {})
+      local_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
+      remote_peer_config = optional(object({
+        allow_virtual_network_access = optional(bool, true)
+        allow_forwarded_traffic      = optional(bool, true)
+        allow_gateway_transit        = optional(bool, false)
+        use_remote_gateways          = optional(bool, false)
+      }), {})
     }))
     load_balancers = optional(map(object({
       name         = string

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -105,6 +105,13 @@ For detailed documentation on each property refer to [module documentation](../v
                               [VNET module documentation](../vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../vnet/README.md#route_tables).
+- `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                              set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                              `use_remote_gateways` parameters on the local VNet peering. 
+- `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                              set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                              `use_remote_gateways` parameters on the remote VNet peering. 
+                                
 
 
 Type: 
@@ -152,6 +159,18 @@ map(object({
       route_table_key                 = optional(string)
       enable_storage_service_endpoint = optional(bool, false)
     })), {})
+    local_peer_config = optional(object({
+      allow_virtual_network_access = optional(bool, true)
+      allow_forwarded_traffic      = optional(bool, true)
+      allow_gateway_transit        = optional(bool, false)
+      use_remote_gateways          = optional(bool, false)
+    }), {})
+    remote_peer_config = optional(object({
+      allow_virtual_network_access = optional(bool, true)
+      allow_forwarded_traffic      = optional(bool, true)
+      allow_gateway_transit        = optional(bool, false)
+      use_remote_gateways          = optional(bool, false)
+    }), {})
   }))
 ```
 

--- a/modules/test_infrastructure/main.tf
+++ b/modules/test_infrastructure/main.tf
@@ -46,14 +46,22 @@ module "vnet_peering" {
   for_each = { for k, v in var.vnets : k => v if v.hub_vnet_name != null }
 
   local_peer_config = {
-    name                = "peer-${each.value.name}-to-${each.value.hub_vnet_name}"
-    resource_group_name = local.resource_group.name
-    vnet_name           = each.value.name
+    name                         = "peer-${each.value.name}-to-${each.value.hub_vnet_name}"
+    resource_group_name          = local.resource_group.name
+    vnet_name                    = each.value.name
+    allow_virtual_network_access = each.value.local_peer_config.allow_virtual_network_access
+    allow_forwarded_traffic      = each.value.local_peer_config.allow_forwarded_traffic
+    allow_gateway_transit        = each.value.local_peer_config.allow_gateway_transit
+    use_remote_gateways          = each.value.local_peer_config.use_remote_gateways
   }
   remote_peer_config = {
-    name                = "peer-${each.value.hub_vnet_name}-to-${each.value.name}"
-    resource_group_name = try(each.value.hub_resource_group_name, local.resource_group.name)
-    vnet_name           = each.value.hub_vnet_name
+    name                         = "peer-${each.value.hub_vnet_name}-to-${each.value.name}"
+    resource_group_name          = try(each.value.hub_resource_group_name, local.resource_group.name)
+    vnet_name                    = each.value.hub_vnet_name
+    allow_virtual_network_access = each.value.remote_peer_config.allow_virtual_network_access
+    allow_forwarded_traffic      = each.value.remote_peer_config.allow_forwarded_traffic
+    allow_gateway_transit        = each.value.remote_peer_config.allow_gateway_transit
+    use_remote_gateways          = each.value.remote_peer_config.use_remote_gateways
   }
 
   depends_on = [module.vnet]
@@ -169,6 +177,8 @@ resource "azurerm_linux_virtual_machine" "this" {
   lifecycle {
     ignore_changes = [source_image_reference["version"]]
   }
+
+  tags = var.tags
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association

--- a/modules/test_infrastructure/variables.tf
+++ b/modules/test_infrastructure/variables.tf
@@ -47,6 +47,13 @@ variable "vnets" {
                                 [VNET module documentation](../vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../vnet/README.md#route_tables).
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
+                                `use_remote_gateways` parameters on the remote VNet peering. 
+                                
   EOF
   type = map(object({
     name                    = string
@@ -90,6 +97,18 @@ variable "vnets" {
       route_table_key                 = optional(string)
       enable_storage_service_endpoint = optional(bool, false)
     })), {})
+    local_peer_config = optional(object({
+      allow_virtual_network_access = optional(bool, true)
+      allow_forwarded_traffic      = optional(bool, true)
+      allow_gateway_transit        = optional(bool, false)
+      use_remote_gateways          = optional(bool, false)
+    }), {})
+    remote_peer_config = optional(object({
+      allow_virtual_network_access = optional(bool, true)
+      allow_forwarded_traffic      = optional(bool, true)
+      allow_gateway_transit        = optional(bool, false)
+      use_remote_gateways          = optional(bool, false)
+    }), {})
   }))
 }
 


### PR DESCRIPTION
## Description

This code contains enhancement to the test_infrastructure_module. Adds support for the VNet peering to enable Remote Gateway use. Also minor change to add tags to the test VMs. Includes also small fix in examples that moves "disable_bgp_route_propagation" parameter under route tables instead of NSGs. 

## Motivation and Context

The current version does not support VNet peering with Remote Gateway in the hub. Disable route propagation is the parameter supported by Route Table instead of Network Security Group. 

## How Has This Been Tested?

Deployed in the lab environment to confirm VNet peering with use of Remote Gateway and disabled route propagation. 

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
