### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in vmseries module

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1134,14 +1134,18 @@ map(object({
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
 ```

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -408,10 +408,14 @@ module "vmseries" {
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    public_ip_resource_group_name  = v.public_ip_resource_group_name
+    pip_domain_name_label          = v.pip_domain_name_label
+    pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+    pip_prefix_name                = v.pip_prefix_name
+    pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+    private_ip_address             = v.private_ip_address
+    attach_to_lb_backend_pool      = v.load_balancer_key != null
+    lb_backend_pool_id             = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -825,14 +825,18 @@ variable "vmseries" {
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1138,14 +1138,18 @@ map(object({
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
 ```

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -408,10 +408,14 @@ module "vmseries" {
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    public_ip_resource_group_name  = v.public_ip_resource_group_name
+    pip_domain_name_label          = v.pip_domain_name_label
+    pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+    pip_prefix_name                = v.pip_prefix_name
+    pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+    private_ip_address             = v.private_ip_address
+    attach_to_lb_backend_pool      = v.load_balancer_key != null
+    lb_backend_pool_id             = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -825,14 +825,18 @@ variable "vmseries" {
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -787,16 +787,20 @@ map(object({
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      gwlb_key                      = optional(string)
-      gwlb_backend_key              = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      gwlb_key                       = optional(string)
+      gwlb_backend_key               = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
 ```

--- a/examples/gwlb_with_vmseries/main.tf
+++ b/examples/gwlb_with_vmseries/main.tf
@@ -290,10 +290,14 @@ module "vmseries" {
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null || v.gwlb_key != null
-    lb_backend_pool_id            = try(module.gwlb[v.gwlb_key].backend_pool_ids[v.gwlb_backend_key], null)
+    public_ip_resource_group_name  = v.public_ip_resource_group_name
+    pip_domain_name_label          = v.pip_domain_name_label
+    pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+    pip_prefix_name                = v.pip_prefix_name
+    pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+    private_ip_address             = v.private_ip_address
+    attach_to_lb_backend_pool      = v.load_balancer_key != null || v.gwlb_key != null
+    lb_backend_pool_id             = try(module.gwlb[v.gwlb_key].backend_pool_ids[v.gwlb_backend_key], null)
   }]
 
   tags = var.tags

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -550,16 +550,20 @@ variable "vmseries" {
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      gwlb_key                      = optional(string)
-      gwlb_backend_key              = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      gwlb_key                       = optional(string)
+      gwlb_backend_key               = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -1069,14 +1069,18 @@ map(object({
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
 ```

--- a/examples/standalone_vmseries/main.tf
+++ b/examples/standalone_vmseries/main.tf
@@ -408,10 +408,14 @@ module "vmseries" {
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    public_ip_resource_group_name  = v.public_ip_resource_group_name
+    pip_domain_name_label          = v.pip_domain_name_label
+    pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
+    pip_prefix_name                = v.pip_prefix_name
+    pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
+    private_ip_address             = v.private_ip_address
+    attach_to_lb_backend_pool      = v.load_balancer_key != null
+    lb_backend_pool_id             = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -825,14 +825,18 @@ variable "vmseries" {
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
+      name                           = string
+      subnet_key                     = string
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address             = optional(string)
+      load_balancer_key              = optional(string)
+      application_gateway_key        = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -285,8 +285,8 @@ Following configuration options are available:
                                      IP Address, possible values are in the range from 4 to 32.
 - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
                                      Addresses should be allocated.
-- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                     existing Public IP Prefix resource. 
+- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VM's RG) name of a Resource Group hosting an existing
+                                     Public IP Prefix resource. 
 - `attach_to_lb_backend_pool`      - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
                                      interface with a Load Balancer backend pool.
 - `lb_backend_pool_id`             - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -51,6 +51,7 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 - `network_interface_backend_address_pool_association` (managed)
 - `public_ip` (managed)
 - `public_ip` (data)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -264,24 +265,32 @@ Interfaces will be attached to VM in the order you define here, therefore:
   
 Following configuration options are available:
 
-- `name`                          - (`string`, required) the interface name.
-- `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
-- `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                    the IP to change.
-- `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-- `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
-                                    interface. When `create_public_ip` is set to `true` this will become a name of a newly
-                                    created Public IP interface. Otherwise this is a name of an existing interfaces that will
-                                    be sourced and attached to the interface.
-- `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                    contains public IP that that will be associated with the interface. Used only when 
-                                    `create_public_ip` is `false`.
-- `attach_to_lb_backend_pool`     - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
-                                    interface with a Load Balancer backend pool.
-- `lb_backend_pool_id`            - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
-                                    interface with.
+- `name`                           - (`string`, required) the interface name.
+- `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+- `private_ip_address`             - (`string`, optional, defaults to `null`) static private IP to assign to the interface. 
+                                     When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                     guaranteed not to change as long as the VM is running. Any stop/deallocate/restart 
+                                     operation might cause the IP to change.
+- `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+- `public_ip_name`                 - (`string`, optional, defaults to `null`) name of the public IP to associate with the
+                                     interface. When `create_public_ip` is set to `true` this will become a name of a newly
+                                     created Public IP interface. Otherwise this is a name of an existing interfaces that will
+                                     be sourced and attached to the interface.
+- `public_ip_resource_group_name`  - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
+                                     contains public IP that that will be associated with the interface. Used only when 
+                                     `create_public_ip` is `false`.
+- `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                     Name Label for each Virtual Machine Instance.
+- `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                     IP Address, possible values are in the range from 4 to 32.
+- `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                     Addresses should be allocated.
+- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                     existing Public IP Prefix resource. 
+- `attach_to_lb_backend_pool`      - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
+                                     interface with a Load Balancer backend pool.
+- `lb_backend_pool_id`             - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
+                                     interface with.
 
 Example:
 
@@ -311,14 +320,18 @@ Type:
 
 ```hcl
 list(object({
-    name                          = string
-    subnet_id                     = string
-    create_public_ip              = optional(bool, false)
-    public_ip_name                = optional(string)
-    public_ip_resource_group_name = optional(string)
-    private_ip_address            = optional(string)
-    lb_backend_pool_id            = optional(string)
-    attach_to_lb_backend_pool     = optional(bool, false)
+    name                           = string
+    subnet_id                      = string
+    create_public_ip               = optional(bool, false)
+    public_ip_name                 = optional(string)
+    public_ip_resource_group_name  = optional(string)
+    private_ip_address             = optional(string)
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
+    lb_backend_pool_id             = optional(string)
+    attach_to_lb_backend_pool      = optional(bool, false)
   }))
 ```
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -10,9 +10,9 @@ data "azurerm_public_ip_prefix" "this" {
 resource "azurerm_public_ip" "this" {
   for_each = { for v in var.interfaces : v.name => v if v.create_public_ip }
 
-  location                = var.region
-  resource_group_name     = var.resource_group_name
   name                    = each.value.public_ip_name
+  resource_group_name     = var.resource_group_name
+  location                = var.region
   allocation_method       = "Static"
   sku                     = "Standard"
   zones                   = var.virtual_machine.zone != null ? [var.virtual_machine.zone] : null

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -1,5 +1,5 @@
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
-data "azurerm_public_ip_prefix" "this" {
+data "azurerm_public_ip_prefix" "allocate" {
   for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
 
   name                = each.value.pip_prefix_name
@@ -18,7 +18,7 @@ resource "azurerm_public_ip" "this" {
   zones                   = var.virtual_machine.zone != null ? [var.virtual_machine.zone] : null
   domain_name_label       = each.value.pip_domain_name_label
   idle_timeout_in_minutes = each.value.pip_idle_timeout_in_minutes
-  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[each.value.name].id, null)
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[each.value.name].id, null)
   tags                    = var.tags
 }
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_public_ip" "this" {
   zones                   = var.virtual_machine.zone != null ? [var.virtual_machine.zone] : null
   domain_name_label       = each.value.pip_domain_name_label
   idle_timeout_in_minutes = each.value.pip_idle_timeout_in_minutes
-  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[nic.value.name].id, null)
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[each.value.name].id, null)
   tags                    = var.tags
 }
 

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -207,8 +207,8 @@ variable "interfaces" {
                                        IP Address, possible values are in the range from 4 to 32.
   - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
                                        Addresses should be allocated.
-  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                       existing Public IP Prefix resource. 
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VM's RG) name of a Resource Group hosting an existing
+                                       Public IP Prefix resource. 
   - `attach_to_lb_backend_pool`      - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
                                        interface with a Load Balancer backend pool.
   - `lb_backend_pool_id`             - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -187,24 +187,32 @@ variable "interfaces" {
   
   Following configuration options are available:
 
-  - `name`                          - (`string`, required) the interface name.
-  - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
-  - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                      skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                      to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                      the IP to change.
-  - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-  - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
-                                      interface. When `create_public_ip` is set to `true` this will become a name of a newly
-                                      created Public IP interface. Otherwise this is a name of an existing interfaces that will
-                                      be sourced and attached to the interface.
-  - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                      contains public IP that that will be associated with the interface. Used only when 
-                                      `create_public_ip` is `false`.
-  - `attach_to_lb_backend_pool`     - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
-                                      interface with a Load Balancer backend pool.
-  - `lb_backend_pool_id`            - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
-                                      interface with.
+  - `name`                           - (`string`, required) the interface name.
+  - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+  - `private_ip_address`             - (`string`, optional, defaults to `null`) static private IP to assign to the interface. 
+                                       When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                       guaranteed not to change as long as the VM is running. Any stop/deallocate/restart 
+                                       operation might cause the IP to change.
+  - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+  - `public_ip_name`                 - (`string`, optional, defaults to `null`) name of the public IP to associate with the
+                                       interface. When `create_public_ip` is set to `true` this will become a name of a newly
+                                       created Public IP interface. Otherwise this is a name of an existing interfaces that will
+                                       be sourced and attached to the interface.
+  - `public_ip_resource_group_name`  - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
+                                       contains public IP that that will be associated with the interface. Used only when 
+                                       `create_public_ip` is `false`.
+  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                       Name Label for each Virtual Machine Instance.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                       IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                       Addresses should be allocated.
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                       existing Public IP Prefix resource. 
+  - `attach_to_lb_backend_pool`      - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
+                                       interface with a Load Balancer backend pool.
+  - `lb_backend_pool_id`             - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
+                                       interface with.
 
   Example:
 
@@ -230,14 +238,18 @@ variable "interfaces" {
   ```
   EOF
   type = list(object({
-    name                          = string
-    subnet_id                     = string
-    create_public_ip              = optional(bool, false)
-    public_ip_name                = optional(string)
-    public_ip_resource_group_name = optional(string)
-    private_ip_address            = optional(string)
-    lb_backend_pool_id            = optional(string)
-    attach_to_lb_backend_pool     = optional(bool, false)
+    name                           = string
+    subnet_id                      = string
+    create_public_ip               = optional(bool, false)
+    public_ip_name                 = optional(string)
+    public_ip_resource_group_name  = optional(string)
+    private_ip_address             = optional(string)
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
+    lb_backend_pool_id             = optional(string)
+    attach_to_lb_backend_pool      = optional(bool, false)
   }))
   validation { # create_public_ip & public_ip_name
     condition = alltrue([
@@ -245,6 +257,14 @@ variable "interfaces" {
     ])
     error_message = <<-EOF
     The `public_ip_name` property is required when `create_public_ip` is set to `true`.
+    EOF
+  }
+  validation { # pip_idle_timeout_in_minutes
+    condition = alltrue([
+      for v in var.interfaces : (v.pip_idle_timeout_in_minutes >= 4 && v.pip_idle_timeout_in_minutes <= 32)
+    if v.pip_idle_timeout_in_minutes != null])
+    error_message = <<-EOF
+    The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF
   }
   validation { # lb_backend_pool_id & attach_to_lb_backend_pool


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IPs for the VM-Series instances from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the interface object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.

Issue #57 concerns VMSS but this PR adds this functionality to `vmseries` module too. There's a separate PR for `vmss` module (#65).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the examples, testing different scenarios.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
