### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in appgw module

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -640,11 +640,14 @@ map(object({
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -199,7 +199,6 @@ module "appgw" {
     each.value.public_ip,
     { name = "${each.value.public_ip.create ? var.name_prefix : ""}${each.value.public_ip.name}" }
   )
-  domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
   enable_http2                   = each.value.enable_http2
   waf                            = each.value.waf

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -343,11 +343,14 @@ variable "appgws" {
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -662,11 +662,14 @@ map(object({
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/common_vmseries_and_autoscale/main.tf
+++ b/examples/common_vmseries_and_autoscale/main.tf
@@ -186,7 +186,6 @@ module "appgw" {
     each.value.public_ip,
     { name = "${each.value.public_ip.create ? var.name_prefix : ""}${each.value.public_ip.name}" }
   )
-  domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
   enable_http2                   = each.value.enable_http2
   waf                            = each.value.waf

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -343,11 +343,14 @@ variable "appgws" {
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -644,11 +644,14 @@ map(object({
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -199,7 +199,6 @@ module "appgw" {
     each.value.public_ip,
     { name = "${each.value.public_ip.create ? var.name_prefix : ""}${each.value.public_ip.name}" }
   )
-  domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
   enable_http2                   = each.value.enable_http2
   waf                            = each.value.waf

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -343,11 +343,14 @@ variable "appgws" {
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -656,11 +656,14 @@ map(object({
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/dedicated_vmseries_and_autoscale/main.tf
+++ b/examples/dedicated_vmseries_and_autoscale/main.tf
@@ -186,7 +186,6 @@ module "appgw" {
     each.value.public_ip,
     { name = "${each.value.public_ip.create ? var.name_prefix : ""}${each.value.public_ip.name}" }
   )
-  domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
   enable_http2                   = each.value.enable_http2
   waf                            = each.value.waf

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -343,11 +343,14 @@ variable "appgws" {
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -575,11 +575,14 @@ map(object({
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/examples/standalone_vmseries/main.tf
+++ b/examples/standalone_vmseries/main.tf
@@ -199,7 +199,6 @@ module "appgw" {
     each.value.public_ip,
     { name = "${each.value.public_ip.create ? var.name_prefix : ""}${each.value.public_ip.name}" }
   )
-  domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
   enable_http2                   = each.value.enable_http2
   waf                            = each.value.waf

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -343,11 +343,14 @@ variable "appgws" {
     subnet_key = string
     zones      = optional(list(string))
     public_ip = object({
-      name                = string
-      create              = optional(bool, true)
-      resource_group_name = optional(string)
+      name                       = string
+      create                     = optional(bool, true)
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     })
-    domain_name_label = optional(string)
     capacity = optional(object({
       static = optional(number)
       autoscale = optional(object({

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -827,6 +827,7 @@ appgws = {
 - `application_gateway` (managed)
 - `public_ip` (managed)
 - `public_ip` (data)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -847,7 +848,6 @@ Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
 [`zones`](#zones) | `list` | A list of zones the Application Gateway should be available in.
-[`domain_name_label`](#domain_name_label) | `string` | A label for the Domain Name.
 [`capacity`](#capacity) | `object` | A map defining whether static or autoscale configuration is used.
 [`enable_http2`](#enable_http2) | `bool` | Enable HTTP2 on the Application Gateway.
 [`waf`](#waf) | `object` | A map defining only the SKU and providing basic WAF (Web Application Firewall) configuration for Application Gateway.
@@ -908,19 +908,33 @@ Type: string
 A map defining listener's public IP configuration.
 
 Following properties are available:
-- `name`                - (`string`, required) name of the Public IP resource.
-- `create`              - (`bool`, optional, defaults to `true`) controls if the Public IP resource is created or sourced.
-- `resource_group_name` - (`string`, optional, defaults to `null`) name of the Resource Group hosting the Public IP resource, 
-                          used only for sourced resources.
+- `name`                       - (`string`, required) name of the Public IP resource.
+- `create`                     - (`bool`, optional, defaults to `true`) controls if the Public IP resource is created or 
+                                 sourced.
+- `resource_group_name`        - (`string`, optional, defaults to `null`) name of the Resource Group hosting the Public IP 
+                                 resource, used only for sourced resources.
+- `domain_name_label`          - (`string`, optional, defaults to `null`) a label for the Domain Name, will be used to make up
+                                 the FQDN. If a domain name label is specified, an A DNS record is created for the Public IP in
+                                 the Microsoft Azure DNS system.
+- `idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public IP
+                                 Address, possible values are in the range from 4 to 32.
+- `prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                 Addresses should be allocated.
+- `prefix_resource_group_name` - (`string`, optional, defaults to the APPGW's RG) name of a Resource Group hosting an existing
+                                 Public IP Prefix resource.
 
 
 Type: 
 
 ```hcl
 object({
-    name                = string
-    create              = optional(bool, true)
-    resource_group_name = optional(string)
+    name                       = string
+    create                     = optional(bool, true)
+    resource_group_name        = optional(string)
+    domain_name_label          = optional(string)
+    idle_timeout_in_minutes    = optional(number)
+    prefix_name                = optional(string)
+    prefix_resource_group_name = optional(string)
   })
 ```
 
@@ -1047,18 +1061,6 @@ For details on zones currently available in a region of your choice refer to
 Type: list(string)
 
 Default value: `[1 2 3]`
-
-<sup>[back to list](#modules-optional-inputs)</sup>
-
-#### domain_name_label
-
-A label for the Domain Name. Will be used to make up the FQDN. 
-If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
-
-
-Type: string
-
-Default value: `&{}`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -22,14 +22,6 @@ data "azurerm_public_ip_prefix" "this" {
   resource_group_name = coalesce(var.public_ip.prefix_resource_group_name, var.resource_group_name)
 }
 
-# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip
-data "azurerm_public_ip" "this" {
-  count = var.public_ip.create ? 0 : 1
-
-  name                = var.public_ip.name
-  resource_group_name = coalesce(var.public_ip.resource_group_name, var.resource_group_name)
-}
-
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip
 resource "azurerm_public_ip" "this" {
   count = var.public_ip.create ? 1 : 0
@@ -42,8 +34,16 @@ resource "azurerm_public_ip" "this" {
   zones                   = var.zones
   domain_name_label       = var.public_ip.domain_name_label
   idle_timeout_in_minutes = var.public_ip.idle_timeout_in_minutes
-  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[each.value.name].id, null)
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[0].id, null)
   tags                    = var.tags
+}
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip
+data "azurerm_public_ip" "this" {
+  count = var.public_ip.create ? 0 : 1
+
+  name                = var.public_ip.name
+  resource_group_name = coalesce(var.public_ip.resource_group_name, var.resource_group_name)
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -14,6 +14,14 @@ locals {
   root_certs_map = { for v in local.root_certs_flat_list : v.name => v.path }
 }
 
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
+data "azurerm_public_ip_prefix" "this" {
+  count = var.public_ip.prefix_name != null ? 1 : 0
+
+  name                = var.public_ip.prefix_name
+  resource_group_name = coalesce(var.public_ip.prefix_resource_group_name, var.resource_group_name)
+}
+
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip
 data "azurerm_public_ip" "this" {
   count = var.public_ip.create ? 0 : 1
@@ -26,15 +34,16 @@ data "azurerm_public_ip" "this" {
 resource "azurerm_public_ip" "this" {
   count = var.public_ip.create ? 1 : 0
 
-  name                = var.public_ip.name
-  resource_group_name = var.resource_group_name
-  location            = var.region
-
-  sku               = "Standard"
-  allocation_method = "Static"
-  domain_name_label = var.domain_name_label
-  zones             = var.zones
-  tags              = var.tags
+  name                    = var.public_ip.name
+  resource_group_name     = var.resource_group_name
+  location                = var.region
+  allocation_method       = "Static"
+  sku                     = "Standard"
+  zones                   = var.zones
+  domain_name_label       = var.public_ip.domain_name_label
+  idle_timeout_in_minutes = var.public_ip.idle_timeout_in_minutes
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[each.value.name].id, null)
+  tags                    = var.tags
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_gateway

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
-data "azurerm_public_ip_prefix" "this" {
+data "azurerm_public_ip_prefix" "allocate" {
   count = var.public_ip.prefix_name != null ? 1 : 0
 
   name                = var.public_ip.prefix_name
@@ -34,7 +34,7 @@ resource "azurerm_public_ip" "this" {
   zones                   = var.zones
   domain_name_label       = var.public_ip.domain_name_label
   idle_timeout_in_minutes = var.public_ip.idle_timeout_in_minutes
-  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.this[0].id, null)
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[0].id, null)
   tags                    = var.tags
 }
 

--- a/modules/appgw/variables.tf
+++ b/modules/appgw/variables.tf
@@ -49,25 +49,38 @@ variable "public_ip" {
   A map defining listener's public IP configuration.
 
   Following properties are available:
-  - `name`                - (`string`, required) name of the Public IP resource.
-  - `create`              - (`bool`, optional, defaults to `true`) controls if the Public IP resource is created or sourced.
-  - `resource_group_name` - (`string`, optional, defaults to `null`) name of the Resource Group hosting the Public IP resource, 
-                            used only for sourced resources.
+  - `name`                       - (`string`, required) name of the Public IP resource.
+  - `create`                     - (`bool`, optional, defaults to `true`) controls if the Public IP resource is created or 
+                                   sourced.
+  - `resource_group_name`        - (`string`, optional, defaults to `null`) name of the Resource Group hosting the Public IP 
+                                   resource, used only for sourced resources.
+  - `domain_name_label`          - (`string`, optional, defaults to `null`) a label for the Domain Name, will be used to make up
+                                   the FQDN. If a domain name label is specified, an A DNS record is created for the Public IP in
+                                   the Microsoft Azure DNS system.
+  - `idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public IP
+                                   Address, possible values are in the range from 4 to 32.
+  - `prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                   Addresses should be allocated.
+  - `prefix_resource_group_name` - (`string`, optional, defaults to the APPGW's RG) name of a Resource Group hosting an existing
+                                   Public IP Prefix resource.
   EOF
   type = object({
-    name                = string
-    create              = optional(bool, true)
-    resource_group_name = optional(string)
+    name                       = string
+    create                     = optional(bool, true)
+    resource_group_name        = optional(string)
+    domain_name_label          = optional(string)
+    idle_timeout_in_minutes    = optional(number)
+    prefix_name                = optional(string)
+    prefix_resource_group_name = optional(string)
   })
-}
-
-variable "domain_name_label" {
-  description = <<-EOF
-  A label for the Domain Name. Will be used to make up the FQDN. 
-  If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
-  EOF
-  default     = null
-  type        = string
+  validation { # idle_timeout_in_minutes
+    condition = var.public_ip.idle_timeout_in_minutes != null ? (
+      var.public_ip.idle_timeout_in_minutes >= 4 && var.public_ip.idle_timeout_in_minutes <= 32
+    ) : true
+    error_message = <<-EOF
+    The `idle_timeout_in_minutes` value must be a number between 4 and 32.
+    EOF
+  }
 }
 
 variable "capacity" {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IP for the Application Gateway Public Frontend from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the `public_ip` object.

It also moves `domain_name_label` property under `public_ip` object, it was a standalone variable before (BREAKING).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.

Issue https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/issues/57 concerns VMSS but this PR adds this functionality to appgw module too. There's a separate PR for vmss module (https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/pull/65).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the examples, testing different scenarios.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
