### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in natgw module

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -472,9 +472,13 @@ map(object({
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -187,9 +187,13 @@ variable "natgws" {
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -494,9 +494,13 @@ map(object({
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -187,9 +187,13 @@ variable "natgws" {
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -476,9 +476,13 @@ map(object({
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -187,9 +187,13 @@ variable "natgws" {
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -488,9 +488,13 @@ map(object({
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -187,9 +187,13 @@ variable "natgws" {
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -407,9 +407,13 @@ map(object({
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -187,9 +187,13 @@ variable "natgws" {
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({
-      create              = bool
-      name                = string
-      resource_group_name = optional(string)
+      create                     = bool
+      name                       = string
+      resource_group_name        = optional(string)
+      domain_name_label          = optional(string)
+      idle_timeout_in_minutes    = optional(number)
+      prefix_name                = optional(string)
+      prefix_resource_group_name = optional(string)
     }))
     public_ip_prefix = optional(object({
       create              = bool

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -62,6 +62,7 @@ by Azure.
 - `nat_gateway` (data)
 - `public_ip` (data)
 - `public_ip_prefix` (data)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -188,10 +189,19 @@ A map defining a Public IP resource.
 
 List of available properties:
 
-- `create`              - (`bool`, required) controls whether a Public IP is created, sourced, or not used at all.
-- `name`                - (`string`, required) name of a created or sourced Public IP.
-- `resource_group_name` - (`string`, optional) name of a resource group hosting the sourced Public IP resource, ignored when
-                          `create = true`.
+- `create`                     - (`bool`, required) controls whether a Public IP is created, sourced, or not used at all.
+- `name`                       - (`string`, required) name of a created or sourced Public IP.
+- `resource_group_name`        - (`string`, optional) name of a resource group hosting the sourced Public IP resource, ignored
+                                 when `create = true`.
+- `domain_name_label`          - (`string`, optional, defaults to `null`) a label for the Domain Name, will be used to make up
+                                 the FQDN. If a domain name label is specified, an A DNS record is created for the Public IP in
+                                 the Microsoft Azure DNS system.
+- `idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public IP
+                                 Address, possible values are in the range from 4 to 32.
+- `prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                 Addresses should be allocated.
+- `prefix_resource_group_name` - (`string`, optional, defaults to the NATGW's RG) name of a Resource Group hosting an existing
+                                 Public IP Prefix resource.
 
 The module operates in 3 modes, depending on combination of `create` and `name` properties:
 
@@ -224,9 +234,13 @@ Type:
 
 ```hcl
 object({
-    create              = bool
-    name                = string
-    resource_group_name = optional(string)
+    create                     = bool
+    name                       = string
+    resource_group_name        = optional(string)
+    domain_name_label          = optional(string)
+    idle_timeout_in_minutes    = optional(number)
+    prefix_name                = optional(string)
+    prefix_resource_group_name = optional(string)
   })
 ```
 

--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -1,15 +1,25 @@
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
+data "azurerm_public_ip_prefix" "allocate" {
+  count = var.public_ip.prefix_name != null ? 1 : 0
+
+  name                = var.public_ip.prefix_name
+  resource_group_name = coalesce(var.public_ip.prefix_resource_group_name, var.resource_group_name)
+}
+
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip
 resource "azurerm_public_ip" "this" {
   count = try(var.create_natgw && var.public_ip.create, false) ? 1 : 0
 
-  name                = var.public_ip.name
-  resource_group_name = var.resource_group_name
-  location            = var.region
-  allocation_method   = "Static"
-  sku                 = "Standard"
-  zones               = var.zone != null ? [var.zone] : null
-
-  tags = var.tags
+  name                    = var.public_ip.name
+  resource_group_name     = var.resource_group_name
+  location                = var.region
+  allocation_method       = "Static"
+  sku                     = "Standard"
+  zones                   = var.zone != null ? [var.zone] : null
+  domain_name_label       = var.public_ip.domain_name_label
+  idle_timeout_in_minutes = var.public_ip.idle_timeout_in_minutes
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[0].id, null)
+  tags                    = var.tags
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip

--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -1,6 +1,6 @@
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
 data "azurerm_public_ip_prefix" "allocate" {
-  count = var.public_ip.prefix_name != null ? 1 : 0
+  count = var.public_ip != null ? (var.public_ip.prefix_name != null ? 1 : 0) : 0
 
   name                = var.public_ip.prefix_name
   resource_group_name = coalesce(var.public_ip.prefix_resource_group_name, var.resource_group_name)

--- a/modules/natgw/variables.tf
+++ b/modules/natgw/variables.tf
@@ -130,7 +130,7 @@ variable "public_ip" {
     prefix_resource_group_name = optional(string)
   })
   validation { # idle_timeout_in_minutes
-    condition = var.public_ip.idle_timeout_in_minutes != null ? (
+    condition = var.public_ip != null && var.public_ip.idle_timeout_in_minutes != null ? (
       var.public_ip.idle_timeout_in_minutes >= 4 && var.public_ip.idle_timeout_in_minutes <= 32
     ) : true
     error_message = <<-EOF

--- a/modules/natgw/variables.tf
+++ b/modules/natgw/variables.tf
@@ -130,8 +130,10 @@ variable "public_ip" {
     prefix_resource_group_name = optional(string)
   })
   validation { # idle_timeout_in_minutes
-    condition = var.public_ip != null && var.public_ip.idle_timeout_in_minutes != null ? (
-      var.public_ip.idle_timeout_in_minutes >= 4 && var.public_ip.idle_timeout_in_minutes <= 32
+    condition = var.public_ip != null ? (
+      var.public_ip.idle_timeout_in_minutes != null ? (
+        var.public_ip.idle_timeout_in_minutes >= 4 && var.public_ip.idle_timeout_in_minutes <= 32
+      ) : true
     ) : true
     error_message = <<-EOF
     The `idle_timeout_in_minutes` value must be a number between 4 and 32.

--- a/modules/natgw/variables.tf
+++ b/modules/natgw/variables.tf
@@ -79,10 +79,19 @@ variable "public_ip" {
 
   List of available properties:
 
-  - `create`              - (`bool`, required) controls whether a Public IP is created, sourced, or not used at all.
-  - `name`                - (`string`, required) name of a created or sourced Public IP.
-  - `resource_group_name` - (`string`, optional) name of a resource group hosting the sourced Public IP resource, ignored when
-                            `create = true`.
+  - `create`                     - (`bool`, required) controls whether a Public IP is created, sourced, or not used at all.
+  - `name`                       - (`string`, required) name of a created or sourced Public IP.
+  - `resource_group_name`        - (`string`, optional) name of a resource group hosting the sourced Public IP resource, ignored
+                                   when `create = true`.
+  - `domain_name_label`          - (`string`, optional, defaults to `null`) a label for the Domain Name, will be used to make up
+                                   the FQDN. If a domain name label is specified, an A DNS record is created for the Public IP in
+                                   the Microsoft Azure DNS system.
+  - `idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public IP
+                                   Address, possible values are in the range from 4 to 32.
+  - `prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                   Addresses should be allocated.
+  - `prefix_resource_group_name` - (`string`, optional, defaults to the NATGW's RG) name of a Resource Group hosting an existing
+                                   Public IP Prefix resource.
 
   The module operates in 3 modes, depending on combination of `create` and `name` properties:
 
@@ -112,10 +121,22 @@ variable "public_ip" {
   EOF
   default     = null
   type = object({
-    create              = bool
-    name                = string
-    resource_group_name = optional(string)
+    create                     = bool
+    name                       = string
+    resource_group_name        = optional(string)
+    domain_name_label          = optional(string)
+    idle_timeout_in_minutes    = optional(number)
+    prefix_name                = optional(string)
+    prefix_resource_group_name = optional(string)
   })
+  validation { # idle_timeout_in_minutes
+    condition = var.public_ip.idle_timeout_in_minutes != null ? (
+      var.public_ip.idle_timeout_in_minutes >= 4 && var.public_ip.idle_timeout_in_minutes <= 32
+    ) : true
+    error_message = <<-EOF
+    The `idle_timeout_in_minutes` value must be a number between 4 and 32.
+    EOF
+  }
 }
 
 variable "public_ip_prefix" {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IP for the NAT Gateway from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the `public_ip` object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.

Issue https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/issues/57 concerns VMSS but this PR adds this functionality to natgw module too. There's a separate PR for vmss module (https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/pull/65).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the examples, testing different scenarios.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
