### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in vng module

### DIFF
--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -332,6 +332,7 @@ variable "virtual_network_gateways" {
 - `virtual_network_gateway` (managed)
 - `virtual_network_gateway_connection` (managed)
 - `public_ip` (data)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -481,13 +482,25 @@ A map defining the Public IPs used by the Virtual Network Gateway.
   
 Following properties are available:
 - `primary`   - (`map`, required) a map defining the primary Public IP address, following properties are available:
-  - `name`                          - (`string`, required) name of the IP config.
-  - `create_public_ip`              - (`bool`, optional, defaults to `true`) controls if a Public IP is created or sourced.
-  - `public_ip_name`                - (`string`, required) name of a Public IP resource, depending on the value of 
-                                      `create_public_ip` property this will be a name of a newly create or existing resource
-                                      (for values of `true` and `false` accordingly).
-  - `dynamic_private_ip_allocation` - (`bool`, optional, defaults to `true`) controls if the private IP address is assigned
-                                      dynamically or statically.
+  - `name`                           - (`string`, required) name of the IP config.
+  - `create_public_ip`               - (`bool`, optional, defaults to `true`) controls if a Public IP is created or sourced.
+  - `public_ip_name`                 - (`string`, required) name of a Public IP resource, depending on the value of 
+                                       `create_public_ip` property this will be a name of a newly create or existing resource
+                                       (for values of `true` and `false` accordingly).
+  - `public_ip_resource_group_name`  - (`string`, optional, defaults to the Load Balancer's RG) name of a Resource Group
+                                       hosting an existing Public IP resource.
+  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) a label for the Domain Name, will be used to
+                                       make up the FQDN. If a domain name label is specified, an A DNS record is created for
+                                       the Public IP in the Microsoft Azure DNS system.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the
+                                       Public IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where
+                                       Public IP Addresses should be allocated (if new PIP is created by the module).
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VM's RG) name of a Resource Group hosting an
+                                       existing Public IP Prefix resource. 
+  - `dynamic_private_ip_allocation`  - (`bool`, optional, defaults to `true`) controls if the private IP address is assigned
+                                       dynamically or statically.
+
 - `secondary` - (`map`, optional, defaults to `null`) a map defining the secondary Public IP address resource. Required only
                 for `type` set to `Vpn` and `active-active` set to `true`. Same properties available as for `primary` property.
 
@@ -498,16 +511,26 @@ Type:
 ```hcl
 object({
     primary = object({
-      name                          = string
-      create_public_ip              = optional(bool, true)
-      public_ip_name                = string
-      private_ip_address_allocation = optional(string, "Dynamic")
+      name                           = string
+      create_public_ip               = optional(bool, true)
+      public_ip_name                 = string
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address_allocation  = optional(string, "Dynamic")
     })
     secondary = optional(object({
-      name                          = string
-      create_public_ip              = optional(bool, true)
-      public_ip_name                = string
-      private_ip_address_allocation = optional(string, "Dynamic")
+      name                           = string
+      create_public_ip               = optional(bool, true)
+      public_ip_name                 = string
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      private_ip_address_allocation  = optional(string, "Dynamic")
     }))
   })
 ```

--- a/modules/virtual_network_gateway/outputs.tf
+++ b/modules/virtual_network_gateway/outputs.tf
@@ -2,7 +2,7 @@ output "public_ip" {
   description = "Public IP addresses for Virtual Network Gateway"
   value = merge(
     { for k, v in azurerm_public_ip.this : k => v.ip_address },
-    { for k, v in data.azurerm_public_ip.exists : k => v.ip_address }
+    { for k, v in data.azurerm_public_ip.this : k => v.ip_address }
   )
 }
 

--- a/tests/virtual_network_gateway/variables.tf
+++ b/tests/virtual_network_gateway/variables.tf
@@ -135,16 +135,26 @@ variable "virtual_network_gateways" {
     })
     ip_configurations = object({
       primary = object({
-        name                          = string
-        create_public_ip              = optional(bool)
-        public_ip_name                = string
-        private_ip_address_allocation = optional(string)
+        name                           = string
+        create_public_ip               = optional(bool)
+        public_ip_name                 = string
+        public_ip_resource_group_name  = optional(string)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        private_ip_address_allocation  = optional(string)
       })
       secondary = optional(object({
-        name                          = string
-        create_public_ip              = optional(bool)
-        public_ip_name                = string
-        private_ip_address_allocation = optional(string)
+        name                           = string
+        create_public_ip               = optional(bool)
+        public_ip_name                 = string
+        public_ip_resource_group_name  = optional(string)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        private_ip_address_allocation  = optional(string)
       }))
     })
     private_ip_address_enabled       = optional(bool)


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IP for the Virtual Network Gateway (VNG) from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the `ip_configurations` object.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.

Issue https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/issues/57 concerns VMSS but this PR adds this functionality to virtual_network_gateway module too. There's a separate PR for vmss module (https://github.com/PaloAltoNetworks/terraform-azurerm-swfw-modules/pull/65).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the examples, testing different scenarios.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
