### PR TITLE
feat: Introduce allocating PIP from existing PIP Prefix in panorama module 

### DIFF
--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -437,12 +437,16 @@ map(object({
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      private_ip_address            = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
+      name                           = string
+      subnet_key                     = string
+      private_ip_address             = optional(string)
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     logging_disks = optional(map(object({
       name      = string

--- a/examples/standalone_panorama/variables.tf
+++ b/examples/standalone_panorama/variables.tf
@@ -236,12 +236,16 @@ variable "panoramas" {
       identity_ids                 = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      private_ip_address            = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
+      name                           = string
+      subnet_key                     = string
+      private_ip_address             = optional(string)
+      create_public_ip               = optional(bool, false)
+      public_ip_name                 = optional(string)
+      public_ip_resource_group_name  = optional(string)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
     }))
     logging_disks = optional(map(object({
       name      = string

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -38,6 +38,7 @@ The acceptance applies to the entirety of your Azure Subscription.
 - `public_ip` (managed)
 - `virtual_machine_data_disk_attachment` (managed)
 - `public_ip` (data)
+- `public_ip_prefix` (data)
 
 ### Required Inputs
 
@@ -235,20 +236,28 @@ Interfaces will be attached to VM in the order you define here, therefore:
   
 Following configuration options are available:
 
-- `name`                          - (`string`, required) the interface name.
-- `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
-- `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                    the IP to change.
-- `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-- `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
-                                    interface. When `create_public_ip` is set to `true` this will become a name of a newly
-                                    created Public IP interface. Otherwise this is a name of an existing interfaces that will
-                                    be sourced and attached to the interface.
-- `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                    contains public IP that that will be associated with the interface. Used only when 
-                                    `create_public_ip` is `false`.
+- `name`                           - (`string`, required) the interface name.
+- `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+- `private_ip_address`             - (`string`, optional, defaults to `null`) static private IP to assign to the interface.
+                                     When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                     guaranteed not to change as long as the VM is running. Any stop/deallocate/restart
+                                     operation might cause the IP to change.
+- `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+- `public_ip_name`                 - (`string`, optional, defaults to `null`) name of the public IP to associate with the
+                                     interface. When `create_public_ip` is set to `true` this will become a name of a newly
+                                     created Public IP interface. Otherwise this is a name of an existing interfaces that will
+                                     be sourced and attached to the interface.
+- `public_ip_resource_group_name`  - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
+                                     contains public IP that that will be associated with the interface. Used only when 
+                                     `create_public_ip` is `false`.
+- `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                     Name Label for each Virtual Machine Instance.
+- `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                     IP Address, possible values are in the range from 4 to 32.
+- `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                     Addresses should be allocated.
+- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VM's RG) name of a Resource Group hosting an existing
+                                     Public IP Prefix resource. 
 
 Example:
 
@@ -276,12 +285,16 @@ Type:
 
 ```hcl
 list(object({
-    name                          = string
-    subnet_id                     = string
-    private_ip_address            = optional(string)
-    create_public_ip              = optional(bool, false)
-    public_ip_name                = optional(string)
-    public_ip_resource_group_name = optional(string)
+    name                           = string
+    subnet_id                      = string
+    private_ip_address             = optional(string)
+    create_public_ip               = optional(bool, false)
+    public_ip_name                 = optional(string)
+    public_ip_resource_group_name  = optional(string)
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
   }))
 ```
 

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -23,12 +23,12 @@ data "azurerm_public_ip" "this" {
 resource "azurerm_network_interface" "this" {
   for_each = { for k, v in var.interfaces : v.name => merge(v, { index = k }) }
 
-  name                          = each.value.name
-  location                      = var.region
-  resource_group_name           = var.resource_group_name
-  enable_accelerated_networking = false
-  enable_ip_forwarding          = false
-  tags                          = var.tags
+  name                           = each.value.name
+  location                       = var.region
+  resource_group_name            = var.resource_group_name
+  accelerated_networking_enabled = false
+  ip_forwarding_enabled          = false
+  tags                           = var.tags
 
   ip_configuration {
     name                          = "primary"

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -1,14 +1,25 @@
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
+data "azurerm_public_ip_prefix" "allocate" {
+  for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
+
+  name                = each.value.pip_prefix_name
+  resource_group_name = coalesce(each.value.pip_prefix_resource_group_name, var.resource_group_name)
+}
+
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip
 resource "azurerm_public_ip" "this" {
   for_each = { for v in var.interfaces : v.name => v if v.create_public_ip }
 
-  location            = var.region
-  resource_group_name = var.resource_group_name
-  name                = each.value.public_ip_name
-  allocation_method   = "Static"
-  sku                 = "Standard"
-  zones               = var.virtual_machine.zone != null ? [var.virtual_machine.zone] : null
-  tags                = var.tags
+  name                    = each.value.public_ip_name
+  resource_group_name     = var.resource_group_name
+  location                = var.region
+  allocation_method       = "Static"
+  sku                     = "Standard"
+  zones                   = var.virtual_machine.zone != null ? [var.virtual_machine.zone] : null
+  domain_name_label       = each.value.pip_domain_name_label
+  idle_timeout_in_minutes = each.value.pip_idle_timeout_in_minutes
+  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[each.value.name].id, null)
+  tags                    = var.tags
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -176,20 +176,28 @@ variable "interfaces" {
   
   Following configuration options are available:
 
-  - `name`                          - (`string`, required) the interface name.
-  - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
-  - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                      skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                      to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                      the IP to change.
-  - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-  - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
-                                      interface. When `create_public_ip` is set to `true` this will become a name of a newly
-                                      created Public IP interface. Otherwise this is a name of an existing interfaces that will
-                                      be sourced and attached to the interface.
-  - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                      contains public IP that that will be associated with the interface. Used only when 
-                                      `create_public_ip` is `false`.
+  - `name`                           - (`string`, required) the interface name.
+  - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
+  - `private_ip_address`             - (`string`, optional, defaults to `null`) static private IP to assign to the interface.
+                                       When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                       guaranteed not to change as long as the VM is running. Any stop/deallocate/restart
+                                       operation might cause the IP to change.
+  - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+  - `public_ip_name`                 - (`string`, optional, defaults to `null`) name of the public IP to associate with the
+                                       interface. When `create_public_ip` is set to `true` this will become a name of a newly
+                                       created Public IP interface. Otherwise this is a name of an existing interfaces that will
+                                       be sourced and attached to the interface.
+  - `public_ip_resource_group_name`  - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
+                                       contains public IP that that will be associated with the interface. Used only when 
+                                       `create_public_ip` is `false`.
+  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                       Name Label for each Virtual Machine Instance.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                       IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                       Addresses should be allocated.
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VM's RG) name of a Resource Group hosting an existing
+                                       Public IP Prefix resource. 
 
   Example:
 
@@ -213,12 +221,16 @@ variable "interfaces" {
   ```
   EOF
   type = list(object({
-    name                          = string
-    subnet_id                     = string
-    private_ip_address            = optional(string)
-    create_public_ip              = optional(bool, false)
-    public_ip_name                = optional(string)
-    public_ip_resource_group_name = optional(string)
+    name                           = string
+    subnet_id                      = string
+    private_ip_address             = optional(string)
+    create_public_ip               = optional(bool, false)
+    public_ip_name                 = optional(string)
+    public_ip_resource_group_name  = optional(string)
+    pip_domain_name_label          = optional(string)
+    pip_idle_timeout_in_minutes    = optional(number)
+    pip_prefix_name                = optional(string)
+    pip_prefix_resource_group_name = optional(string)
   }))
   validation { # public_ip_name
     condition = alltrue([
@@ -227,6 +239,14 @@ variable "interfaces" {
     ])
     error_message = <<-EOF
     The `public_ip_name` property is required when `create_public_ip` is `true`.
+    EOF
+  }
+  validation { # pip_idle_timeout_in_minutes
+    condition = alltrue([
+      for v in var.interfaces : (v.pip_idle_timeout_in_minutes >= 4 && v.pip_idle_timeout_in_minutes <= 32)
+    if v.pip_idle_timeout_in_minutes != null])
+    error_message = <<-EOF
+    The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces the ability to allocate created public IPs for the Panorama instances from an existing Public IP Prefix range. It's achieved by adding a few additional properties to the interface object.

Additionally, this PR replaces deprecated properties in the `azurerm_network_interface` resource in `panorama` module:

`enable_accelerated_networking` -> `accelerated_networking_enabled`
`enable_ip_forwarding` -> `ip_forwarding_enabled`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If you wanted the Public IP Addresses to be allocated from a Public IP Prefix range (e.g. a custom one, not Microsoft-owned), it was not possible.

Issue #57 concerns VMSS but this PR adds this functionality to `panorama` module too. There's a separate PR for `vmss` module (#65).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, by manually deploying the panorama example.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
