### PR TITLE
fix: Allow to change Public IP for an LB Frontend

### DIFF
--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -41,6 +41,10 @@ resource "azurerm_public_ip" "this" {
   sku                 = "Standard"
   zones               = var.zones
   tags                = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds a lifecycle block with `create_before_destroy` option set to `true` for a `azurerm_public_ip` resource in `loadbalancer` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Azure API didn't allow to replace the public ip resource in Public Load Balancer Frontend when changed in tfvars.
#74 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By deploying one of the examples and replicating the problem.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
