### PR TITLE
fix: Allow to change Health Probe for an LB Rule

### DIFF
--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -140,6 +140,10 @@ resource "azurerm_lb_probe" "this" {
   # this is to overcome the discrepancy between the provider and Azure defaults
   # for more details see here -> https://learn.microsoft.com/en-gb/azure/load-balancer/whats-new#known-issues:~:text=SNAT%20port%20exhaustion-,numberOfProbes,-%2C%20%22Unhealthy%20threshold%22
   number_of_probes = 1
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/lb_rule


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds a lifecycle block with `create_before_destroy` option set to `true` for a `azurerm_lb_probe` resource in `loadbalancer` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Azure API didn't allow to replace the health probe resource in Load Balancer Rule when changed in tfvars.
#75 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By deploying one of the examples and replicating the problem.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
