### PR TITLE
feat(vmseries): VMSeries appgw backend pool association

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1132,7 +1132,9 @@ The most basic properties are as follows:
                                 backend pool.
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                 variable, network interface that has this property defined will be added to the Application
-                                Gateway's backend pool.
+                                Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+  - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
   For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
 
@@ -1194,6 +1196,7 @@ map(object({
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
 ```

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -442,6 +442,8 @@ module "vmseries" {
     private_ip_address            = v.private_ip_address
     attach_to_lb_backend_pool     = v.load_balancer_key != null
     lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -815,7 +815,9 @@ variable "vmseries" {
                                   backend pool.
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                   variable, network interface that has this property defined will be added to the Application
-                                  Gateway's backend pool.
+                                  Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+    - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                  the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
     For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
   EOF
@@ -875,6 +877,7 @@ variable "vmseries" {
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
@@ -899,6 +902,22 @@ variable "vmseries" {
     error_message = <<-EOF
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
+  }
+  validation {
+    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+    condition = alltrue([
+      for _, v in var.vmseries : alltrue([
+        for nic in v.interfaces :
+        (
+          (nic.application_gateway_key == null || nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key != null && nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key == null && nic.appgw_backend_pool_id != null)
+        )
+      ])
+    ])
+    error_message = <<-EOF
+    Only one of `application_gateway_key` or `appgw_backend_pool_id` can be set under an interface, but not both.
+  EOF
   }
 }
 

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -903,8 +903,7 @@ variable "vmseries" {
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
   }
-  validation {
-    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+  validation { # interfaces.application_gateway_key & interfaces.appgw_backend_pool_id
     condition = alltrue([
       for _, v in var.vmseries : alltrue([
         for nic in v.interfaces :

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1136,7 +1136,9 @@ The most basic properties are as follows:
                                 backend pool.
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                 variable, network interface that has this property defined will be added to the Application
-                                Gateway's backend pool.
+                                Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+  - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
   For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
 
@@ -1198,6 +1200,7 @@ map(object({
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
 ```

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -442,6 +442,8 @@ module "vmseries" {
     private_ip_address            = v.private_ip_address
     attach_to_lb_backend_pool     = v.load_balancer_key != null
     lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -815,7 +815,9 @@ variable "vmseries" {
                                   backend pool.
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                   variable, network interface that has this property defined will be added to the Application
-                                  Gateway's backend pool.
+                                  Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+    - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                  the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
     For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
   EOF
@@ -875,6 +877,7 @@ variable "vmseries" {
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
@@ -900,6 +903,23 @@ variable "vmseries" {
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
   }
+  validation {
+    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+    condition = alltrue([
+      for _, v in var.vmseries : alltrue([
+        for nic in v.interfaces :
+        (
+          (nic.application_gateway_key == null || nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key != null && nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key == null && nic.appgw_backend_pool_id != null)
+        )
+      ])
+    ])
+    error_message = <<-EOF
+    Only one of `application_gateway_key` or `appgw_backend_pool_id` can be set under an interface, but not both.
+  EOF
+  }
+}
 }
 
 # TEST INFRASTRUCTURE

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -920,7 +920,6 @@ variable "vmseries" {
   EOF
   }
 }
-}
 
 # TEST INFRASTRUCTURE
 

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -903,8 +903,7 @@ variable "vmseries" {
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
   }
-  validation {
-    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+  validation { # interfaces.application_gateway_key & interfaces.appgw_backend_pool_id
     condition = alltrue([
       for _, v in var.vmseries : alltrue([
         for nic in v.interfaces :

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -781,7 +781,9 @@ The most basic properties are as follows:
                                 backend pool.
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                 variable, network interface that has this property defined will be added to the Application
-                                Gateway's backend pool.
+                                Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+  - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
   For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
 
@@ -844,6 +846,7 @@ map(object({
       gwlb_key                      = optional(string)
       gwlb_backend_key              = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
 ```

--- a/examples/gwlb_with_vmseries/main.tf
+++ b/examples/gwlb_with_vmseries/main.tf
@@ -315,6 +315,8 @@ module "vmseries" {
     private_ip_address            = v.private_ip_address
     attach_to_lb_backend_pool     = v.load_balancer_key != null || v.gwlb_key != null
     lb_backend_pool_id            = try(module.gwlb[v.gwlb_key].backend_pool_ids[v.gwlb_backend_key], null)
+    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -624,8 +624,7 @@ variable "vmseries" {
     The `data_snet_key` is required when `bootstrap_xml_template` is set.
     EOF
   }
-  validation {
-    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+  validation { # interfaces.application_gateway_key & interfaces.appgw_backend_pool_id
     condition = alltrue([
       for _, v in var.vmseries : alltrue([
         for nic in v.interfaces :

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -536,7 +536,9 @@ variable "vmseries" {
                                   backend pool.
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                   variable, network interface that has this property defined will be added to the Application
-                                  Gateway's backend pool.
+                                  Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+    - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                  the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
     For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
   EOF
@@ -597,6 +599,7 @@ variable "vmseries" {
       gwlb_key                      = optional(string)
       gwlb_backend_key              = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
@@ -620,6 +623,22 @@ variable "vmseries" {
     error_message = <<-EOF
     The `data_snet_key` is required when `bootstrap_xml_template` is set.
     EOF
+  }
+  validation {
+    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+    condition = alltrue([
+      for _, v in var.vmseries : alltrue([
+        for nic in v.interfaces :
+        (
+          (nic.application_gateway_key == null || nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key != null && nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key == null && nic.appgw_backend_pool_id != null)
+        )
+      ])
+    ])
+    error_message = <<-EOF
+    Only one of `application_gateway_key` or `appgw_backend_pool_id` can be set under an interface, but not both.
+  EOF
   }
 }
 

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -1070,7 +1070,9 @@ The most basic properties are as follows:
                                 backend pool.
   - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                 variable, network interface that has this property defined will be added to the Application
-                                Gateway's backend pool.
+                                Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+  - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
   For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
 
@@ -1132,6 +1134,7 @@ map(object({
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
 ```

--- a/examples/standalone_vmseries/main.tf
+++ b/examples/standalone_vmseries/main.tf
@@ -442,6 +442,8 @@ module "vmseries" {
     private_ip_address            = v.private_ip_address
     attach_to_lb_backend_pool     = v.load_balancer_key != null
     lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -815,7 +815,9 @@ variable "vmseries" {
                                   backend pool.
     - `application_gateway_key` - (`string`, optional, defaults to `null`) key of an Application Gateway defined in `var.appgws`
                                   variable, network interface that has this property defined will be added to the Application
-                                  Gateway's backend pool.
+                                  Gateway's backend pool. Mutually exclusive with `appgw_backend_pool_id`.
+    - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
+                                  the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
     For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
   EOF
@@ -875,6 +877,7 @@ variable "vmseries" {
       private_ip_address            = optional(string)
       load_balancer_key             = optional(string)
       application_gateway_key       = optional(string)
+      appgw_backend_pool_id         = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
@@ -899,6 +902,22 @@ variable "vmseries" {
     error_message = <<-EOF
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
+  }
+  validation {
+    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+    condition = alltrue([
+      for _, v in var.vmseries : alltrue([
+        for nic in v.interfaces :
+        (
+          (nic.application_gateway_key == null || nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key != null && nic.appgw_backend_pool_id == null) ||
+          (nic.application_gateway_key == null && nic.appgw_backend_pool_id != null)
+        )
+      ])
+    ])
+    error_message = <<-EOF
+    Only one of `application_gateway_key` or `appgw_backend_pool_id` can be set under an interface, but not both.
+  EOF
   }
 }
 

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -903,8 +903,7 @@ variable "vmseries" {
     The `private_snet_key` and `public_snet_key` are required when `bootstrap_xml_template` is set.
     EOF
   }
-  validation {
-    # Ensure only one of `application_gateway_key` or `appgw_backend_pool_id` is set under an interface.
+  validation { # interfaces.application_gateway_key & interfaces.appgw_backend_pool_id
     condition = alltrue([
       for _, v in var.vmseries : alltrue([
         for nic in v.interfaces :

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -48,6 +48,7 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 
 - `linux_virtual_machine` (managed)
 - `network_interface` (managed)
+- `network_interface_application_gateway_backend_address_pool_association` (managed)
 - `network_interface_backend_address_pool_association` (managed)
 - `public_ip` (managed)
 - `public_ip` (data)
@@ -287,6 +288,10 @@ Following configuration options are available:
                                     interface with a Load Balancer backend pool.
 - `lb_backend_pool_id`            - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
                                     interface with.
+- `appgw_backend_pool_id`         - (`string`, optional, defaults to `null`) ID of an existing Application Gateway backend pool
+                                    to associate the interface with.
+- `attach_to_appgw_backend_pool`  - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
+                                    interface with an Application Gateway backend pool.
 
 Example:
 
@@ -325,6 +330,8 @@ list(object({
     private_ip_address            = optional(string)
     lb_backend_pool_id            = optional(string)
     attach_to_lb_backend_pool     = optional(bool, false)
+    appgw_backend_pool_id         = optional(string)
+    attach_to_appgw_backend_pool  = optional(bool, false)
   }))
 ```
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -133,3 +133,18 @@ resource "azurerm_network_interface_backend_address_pool_association" "this" {
     azurerm_linux_virtual_machine.this
   ]
 }
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_gateway_backend_address_pool_association
+resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "this" {
+
+  for_each = { for v in var.interfaces : v.name => v.appgw_backend_pool_id if v.attach_to_appgw_backend_pool }
+
+  network_interface_id    = azurerm_network_interface.this[each.key].id
+  ip_configuration_name   = azurerm_network_interface.this[each.key].ip_configuration[0].name
+  backend_address_pool_id = each.value
+
+  depends_on = [
+    azurerm_network_interface.this,
+    azurerm_linux_virtual_machine.this
+  ]
+}

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -218,6 +218,10 @@ variable "interfaces" {
                                       interface with a Load Balancer backend pool.
   - `lb_backend_pool_id`            - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
                                       interface with.
+  - `appgw_backend_pool_id`         - (`string`, optional, defaults to `null`) ID of an existing Application Gateway backend pool
+                                      to associate the interface with.
+  - `attach_to_appgw_backend_pool`  - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
+                                      interface with an Application Gateway backend pool.
 
   Example:
 
@@ -252,6 +256,8 @@ variable "interfaces" {
     private_ip_address            = optional(string)
     lb_backend_pool_id            = optional(string)
     attach_to_lb_backend_pool     = optional(bool, false)
+    appgw_backend_pool_id         = optional(string)
+    attach_to_appgw_backend_pool  = optional(bool, false)
   }))
   validation { # create_public_ip, public_ip_name
     condition = alltrue([
@@ -275,6 +281,14 @@ variable "interfaces" {
     ])
     error_message = <<-EOF
     The `lb_backend_pool_id` cannot be `null` when `attach_to_lb_backend_pool` is set to `true`.
+    EOF
+  }
+  validation {
+    condition = alltrue([
+      for v in var.interfaces : v.appgw_backend_pool_id != null if v.attach_to_appgw_backend_pool
+    ])
+    error_message = <<-EOF
+    The `appgw_backend_pool_id` cannot be `null` when `attach_to_appgw_backend_pool` is set to `true`.
     EOF
   }
 }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -283,7 +283,7 @@ variable "interfaces" {
     The `lb_backend_pool_id` cannot be `null` when `attach_to_lb_backend_pool` is set to `true`.
     EOF
   }
-  validation {
+  validation { # appgw_backend_pool_id & attach_to_appgw_backend_pool
     condition = alltrue([
       for v in var.interfaces : v.appgw_backend_pool_id != null if v.attach_to_appgw_backend_pool
     ])


### PR DESCRIPTION
## Description

- Add possibility to attach vmseries interfaces to existing AppGW .
- This PR closes #88 .

## Motivation and Context

- No current way to attach existing VMSeries interfaces to AppGW just like you would attach it to a regular Loadbalancer (from within the module).

## How Has This Been Tested?

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
