### PR TITLE
fix: Restrict maximum AzureRM provider version for bootstrap module

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -132,11 +132,11 @@ details refer to the [var.file_shares](#file_shares) variable documentation.
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 3.98
+- `azurerm`, version: ~> 3.98, <= 3.114
 
 ### Providers
 
-- `azurerm`, version: ~> 3.98
+- `azurerm`, version: ~> 3.98, <= 3.114
 
 
 

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.98"
+      version = "~> 3.98, <= 3.114"
     }
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds a new AzureRM provider version constraint that limits maximum provider version to `3.114` in the bootstrap module (temporary solution) due to a provider bug.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our examples utilising bootstrap module currently are not idempotent with the newest AzureRM provider within v3 major branch. It's fixed in AzureRM provider v4 (which is going to be introduced in the next minor version release). Temporarily we need to restrict the maximum version before the bug was introduced.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ChatOps

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
