### PR TITLE
docs: Add information about subscription_id to READMEs

### DIFF
--- a/examples/common_vmseries/.header.md
+++ b/examples/common_vmseries/.header.md
@@ -90,7 +90,10 @@ A list of requirements might vary depending on the platform used to deploy the i
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs
   (take a closer look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -90,7 +90,10 @@ A list of requirements might vary depending on the platform used to deploy the i
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs
   (take a closer look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/common_vmseries_and_autoscale/.header.md
+++ b/examples/common_vmseries_and_autoscale/.header.md
@@ -128,7 +128,10 @@ A non-platform requirement would be a running Panorama instance. For full automa
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for the scale set [`common`](./example.tfvars#L224).
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -128,7 +128,10 @@ A non-platform requirement would be a running Panorama instance. For full automa
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for the scale set [`common`](./example.tfvars#L224).
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/dedicated_vmseries/.header.md
+++ b/examples/dedicated_vmseries/.header.md
@@ -92,7 +92,10 @@ A list of requirements might vary depending on the platform used to deploy the i
   look at the `TODO` markers)
 - copy the [`init-cfg.sample.txt`](./files/init-cfg.sample.txt) to `init-cfg.txt` and fill it out with required bootstrap 
   parameters (see this [documentation](https://docs.paloaltonetworks.com/vm-series/9-1/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components#id07933d91-15be-414d-bc8d-f2a5f3d8df6b) for details)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -92,7 +92,10 @@ A list of requirements might vary depending on the platform used to deploy the i
   look at the `TODO` markers)
 - copy the [`init-cfg.sample.txt`](./files/init-cfg.sample.txt) to `init-cfg.txt` and fill it out with required bootstrap
   parameters (see this [documentation](https://docs.paloaltonetworks.com/vm-series/9-1/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components#id07933d91-15be-414d-bc8d-f2a5f3d8df6b) for details)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/dedicated_vmseries_and_autoscale/.header.md
+++ b/examples/dedicated_vmseries_and_autoscale/.header.md
@@ -122,7 +122,10 @@ requirements:
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for each scale set ([inbound](./example.tfvars#L205) and
   [obew](./example.tfvars#L249) separately).
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -122,7 +122,10 @@ requirements:
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for each scale set ([inbound](./example.tfvars#L205) and
   [obew](./example.tfvars#L249) separately).
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/gwlb_with_vmseries/.header.md
+++ b/examples/gwlb_with_vmseries/.header.md
@@ -52,43 +52,46 @@ A list of requirements might vary depending on the platform used to deploy the i
 
 ### Deployment Steps
 
-* Checkout the code locally.
-* Copy `example.tfvars` to `terraform.tfvars` and adjust it to your needs.
-* Copy `files/init-cfg.txt.sample` to `files/init-cfg.txt` and fill it in with required bootstrap parameters (see this
+- checkout the code locally
+- copy `example.tfvars` to `terraform.tfvars` and adjust it to your needs
+- copy `files/init-cfg.txt.sample` to `files/init-cfg.txt` and fill it in with required bootstrap parameters (see this
 [documentation](https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components)
-for details).
-* _(optional)_ Authenticate to AzureRM, switch to the Subscription of your choice if necessary.
-* Initialize the Terraform module:
+for details)
+- _(optional)_ Authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
+- initialize the Terraform module:
 
 ```bash
 terraform init
 ```
 
-* _(optional)_ Plan you infrastructure to see what will be actually deployed:
+- _(optional)_ plan you infrastructure to see what will be actually deployed:
 
 ```bash
 terraform plan
 ```
 
-* Deploy the infrastructure:
+- deploy the infrastructure (you will have to confirm it with typing in `yes`):
 
 ```bash
 terraform apply
 ```
 
-* At this stage you have to wait a few minutes for the firewalls to bootstrap.
+- At this stage you have to wait a few minutes for the firewalls to bootstrap.
 
 ### Post deploy
 
 Firewalls in this example are configured with password authentication. To retrieve the initial credentials run:
 
-* for username:
+- for username:
 
 ```bash
 terraform output username
 ```
 
-* for password:
+- for password:
 
 ```bash
 terraform output password
@@ -102,8 +105,8 @@ terraform output vmseries_mgmt_ips
 
 You can now login to the devices using either:
 
-* CLI - ssh client is required
-* Web UI (https) - any modern web browser, note that initially the traffic is encrypted with a self-signed certificate.
+- CLI - ssh client is required
+- Web UI (https) - any modern web browser, note that initially the traffic is encrypted with a self-signed certificate.
 
 With default example configuration, the devices already contain `DAY0` configuration, so all network interfaces should be
 configured and Azure Gateway Load Balancer should already report that the devices are healthy.

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -52,43 +52,46 @@ A list of requirements might vary depending on the platform used to deploy the i
 
 ### Deployment Steps
 
-* Checkout the code locally.
-* Copy `example.tfvars` to `terraform.tfvars` and adjust it to your needs.
-* Copy `files/init-cfg.txt.sample` to `files/init-cfg.txt` and fill it in with required bootstrap parameters (see this
+- checkout the code locally
+- copy `example.tfvars` to `terraform.tfvars` and adjust it to your needs
+- copy `files/init-cfg.txt.sample` to `files/init-cfg.txt` and fill it in with required bootstrap parameters (see this
 [documentation](https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components)
-for details).
-* _(optional)_ Authenticate to AzureRM, switch to the Subscription of your choice if necessary.
-* Initialize the Terraform module:
+for details)
+- _(optional)_ Authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
+- initialize the Terraform module:
 
 ```bash
 terraform init
 ```
 
-* _(optional)_ Plan you infrastructure to see what will be actually deployed:
+- _(optional)_ plan you infrastructure to see what will be actually deployed:
 
 ```bash
 terraform plan
 ```
 
-* Deploy the infrastructure:
+- deploy the infrastructure (you will have to confirm it with typing in `yes`):
 
 ```bash
 terraform apply
 ```
 
-* At this stage you have to wait a few minutes for the firewalls to bootstrap.
+- At this stage you have to wait a few minutes for the firewalls to bootstrap.
 
 ### Post deploy
 
 Firewalls in this example are configured with password authentication. To retrieve the initial credentials run:
 
-* for username:
+- for username:
 
 ```bash
 terraform output username
 ```
 
-* for password:
+- for password:
 
 ```bash
 terraform output password
@@ -102,8 +105,8 @@ terraform output vmseries_mgmt_ips
 
 You can now login to the devices using either:
 
-* CLI - ssh client is required
-* Web UI (https) - any modern web browser, note that initially the traffic is encrypted with a self-signed certificate.
+- CLI - ssh client is required
+- Web UI (https) - any modern web browser, note that initially the traffic is encrypted with a self-signed certificate.
 
 With default example configuration, the devices already contain `DAY0` configuration, so all network interfaces should be
 configured and Azure Gateway Load Balancer should already report that the devices are healthy.

--- a/examples/standalone_panorama/.header.md
+++ b/examples/standalone_panorama/.header.md
@@ -47,7 +47,10 @@ A list of requirements might vary depending on the platform used to deploy the i
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -47,7 +47,10 @@ A list of requirements might vary depending on the platform used to deploy the i
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/standalone_vmseries/.header.md
+++ b/examples/standalone_vmseries/.header.md
@@ -40,7 +40,10 @@ Steps to deploy the infrastructure are as following:
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs
   (take a closer look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -40,7 +40,10 @@ Steps to deploy the infrastructure are as following:
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs
   (take a closer look at the `TODO` markers)
-- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice if necessary
+- _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
+- provide `subscription_id` property under the `azurerm` provider block in [`versions.tf`](./versions.tf) file or create an
+  environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value in your shell (required since AzureRM provider
+  version 4 as per [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#subscription_id))
 - initialize the Terraform module:
 
   ```bash


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR updates the examples READMEs, specifically adds a new deployment step which is providing the Subscription ID.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since AzureRM provider version 4 it's required to provide Subscription ID to run `terraform plan` or `terraform apply`.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
