### PR TITLE
fix: Disable the use of local users for Storage Account

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_storage_account" "this" {
   resource_group_name             = var.resource_group_name
   min_tls_version                 = var.storage_network_security.min_tls_version
   allow_nested_items_to_be_public = false
+  local_user_enabled              = false
   account_replication_type        = var.storage_account.replication_type
   account_tier                    = var.storage_account.tier
   account_kind                    = var.storage_account.kind


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR disables the use of local users for Azure Storage Account (enabled by default) within the `bootstrap` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In `checkov` version `3.2.255`, the hook failed due to check `CKV_AZURE_244` ("Avoid the use of local users for Azure Storage unless necessary").

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually deployed an example with full bootstrap to make sure it's still working as intended.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
