### PR TITLE
feat(vnet)!: per-subnet sourcing and subnet delegation for CloudNGFW

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -279,31 +279,29 @@ For detailed documentation on each property refer to [module documentation](../.
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -335,13 +333,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -1230,14 +1229,12 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
@@ -1315,8 +1312,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1349,13 +1346,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -64,8 +64,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -58,27 +58,25 @@ variable "vnets" {
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -946,14 +945,12 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
@@ -1029,8 +1026,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1063,13 +1060,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -295,38 +295,36 @@ Type: string
 #### vnets
 
 A map defining VNETs.
-  
+
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
 - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -358,13 +356,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -1112,20 +1111,18 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering. 
+                                `use_remote_gateways` parameters on the remote VNet peering.  
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -1197,8 +1194,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1231,13 +1228,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/common_vmseries_and_autoscale/main.tf
+++ b/examples/common_vmseries_and_autoscale/main.tf
@@ -67,8 +67,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -51,34 +51,32 @@ variable "tags" {
 variable "vnets" {
   description = <<-EOF
   A map defining VNETs.
-  
+
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
   - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -758,20 +757,18 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering. 
+                                  `use_remote_gateways` parameters on the remote VNet peering.  
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -841,8 +838,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -875,13 +872,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -283,31 +283,29 @@ For detailed documentation on each property refer to [module documentation](../.
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -339,13 +337,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -1234,14 +1233,12 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
@@ -1319,8 +1316,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1353,13 +1350,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -64,8 +64,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -58,27 +58,25 @@ variable "vnets" {
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -946,14 +945,12 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
@@ -1029,8 +1026,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1063,13 +1060,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -289,38 +289,36 @@ Type: string
 #### vnets
 
 A map defining VNETs.
-  
+
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
 - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -352,13 +350,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -1106,20 +1105,18 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering. 
+                                `use_remote_gateways` parameters on the remote VNet peering.  
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -1191,8 +1188,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1225,13 +1222,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/dedicated_vmseries_and_autoscale/main.tf
+++ b/examples/dedicated_vmseries_and_autoscale/main.tf
@@ -67,8 +67,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -51,34 +51,32 @@ variable "tags" {
 variable "vnets" {
   description = <<-EOF
   A map defining VNETs.
-  
+
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
   - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -758,20 +757,18 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering. 
+                                  `use_remote_gateways` parameters on the remote VNet peering.  
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -841,8 +838,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -875,13 +872,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -213,38 +213,36 @@ Type: string
 #### vnets
 
 A map defining VNETs.
-  
+
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
 - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -276,13 +274,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -880,20 +879,18 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering. 
+                                `use_remote_gateways` parameters on the remote VNet peering.  
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -965,8 +962,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -999,13 +996,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/gwlb_with_vmseries/main.tf
+++ b/examples/gwlb_with_vmseries/main.tf
@@ -64,8 +64,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -51,34 +51,32 @@ variable "tags" {
 variable "vnets" {
   description = <<-EOF
   A map defining VNETs.
-  
+
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
   - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -667,20 +666,18 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering. 
+                                  `use_remote_gateways` parameters on the remote VNet peering.  
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 
@@ -750,8 +747,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -784,13 +781,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/standalone_panorama/README.md
+++ b/examples/standalone_panorama/README.md
@@ -192,38 +192,36 @@ Type: string
 #### vnets
 
 A map defining VNETs.
-  
+
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
 - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -255,13 +253,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```

--- a/examples/standalone_panorama/main.tf
+++ b/examples/standalone_panorama/main.tf
@@ -64,8 +64,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/standalone_panorama/variables.tf
+++ b/examples/standalone_panorama/variables.tf
@@ -51,34 +51,32 @@ variable "tags" {
 variable "vnets" {
   description = <<-EOF
   A map defining VNETs.
-  
+
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
   - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -217,31 +217,29 @@ For detailed documentation on each property refer to [module documentation](../.
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
 - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                               set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                               disabled.
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -273,13 +271,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```
@@ -1168,14 +1167,12 @@ Following properties are supported:
                                 a full resource name, including prefixes.
   - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                 created VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
@@ -1253,8 +1250,8 @@ map(object({
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1287,13 +1284,14 @@ map(object({
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/examples/standalone_vmseries/main.tf
+++ b/examples/standalone_vmseries/main.tf
@@ -64,8 +64,7 @@ module "vnet" {
   dns_servers     = each.value.dns_servers
   vnet_encryption = each.value.vnet_encryption
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -58,27 +58,25 @@ variable "vnets" {
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
   - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
                                 set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
                                 disabled.
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
     vnet_encryption        = optional(string)
@@ -110,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }
@@ -946,14 +945,12 @@ variable "test_infrastructure" {
                                   a full resource name, including prefixes.
     - `address_space`           - (`list(string)`, required when `create_virtual_network = `false`) a list of CIDRs for a newly
                                   created VNET.
-    - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                  otherwise use source existing subnets.
-    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
     - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
+    - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                  [VNET module documentation](../../modules/vnet/README.md#subnets).
     - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                   set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                   `use_remote_gateways` parameters on the local VNet peering. 
@@ -1029,8 +1026,8 @@ variable "test_infrastructure" {
     create_resource_group = optional(bool, true)
     resource_group_name   = optional(string)
     vnets = map(object({
-      name                    = string
       create_virtual_network  = optional(bool, true)
+      name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
       hub_resource_group_name = optional(string)
@@ -1063,13 +1060,14 @@ variable "test_infrastructure" {
           next_hop_ip_address = optional(string)
         }))
       })), {})
-      create_subnets = optional(bool, true)
       subnets = optional(map(object({
+        create                          = optional(bool, true)
         name                            = string
         address_prefixes                = optional(list(string), [])
         network_security_group_key      = optional(string)
         route_table_key                 = optional(string)
-        enable_storage_service_endpoint = optional(bool, false)
+        enable_storage_service_endpoint = optional(bool)
+        enable_cloudngfw_delegation     = optional(bool)
       })), {})
       local_peer_config = optional(object({
         allow_virtual_network_access = optional(bool, true)

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -98,29 +98,26 @@ For detailed documentation on each property refer to [module documentation](../v
                               value is necessary to create peering between the spoke and the hub VNET.
 - `hub_vnet_name`           - (`string`, optional) Name of the hub/transit VNET. This value is required to create peering
                               between the spoke and the hub VNET.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../vnet/README.md#subnets).
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../vnet/README.md#subnets).
 - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                               set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                               `use_remote_gateways` parameters on the local VNet peering. 
 - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                               set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                              `use_remote_gateways` parameters on the remote VNet peering. 
-                                
+                              `use_remote_gateways` parameters on the remote VNet peering.                  
 
 
 Type: 
 
 ```hcl
 map(object({
-    name                    = string
     create_virtual_network  = optional(bool, true)
+    name                    = string
     address_space           = optional(list(string))
     hub_resource_group_name = optional(string)
     hub_vnet_name           = optional(string)
@@ -152,8 +149,8 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)

--- a/modules/test_infrastructure/main.tf
+++ b/modules/test_infrastructure/main.tf
@@ -30,8 +30,7 @@ module "vnet" {
 
   address_space = each.value.address_space
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = each.value.network_security_groups
   route_tables            = each.value.route_tables

--- a/modules/test_infrastructure/variables.tf
+++ b/modules/test_infrastructure/variables.tf
@@ -39,25 +39,22 @@ variable "vnets" {
                                 value is necessary to create peering between the spoke and the hub VNET.
   - `hub_vnet_name`           - (`string`, optional) Name of the hub/transit VNET. This value is required to create peering
                                 between the spoke and the hub VNET.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../vnet/README.md#subnets).
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../vnet/README.md#subnets).
   - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
                                 `use_remote_gateways` parameters on the local VNet peering. 
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
                                 set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering. 
-                                
+                                `use_remote_gateways` parameters on the remote VNet peering.                  
   EOF
   type = map(object({
-    name                    = string
     create_virtual_network  = optional(bool, true)
+    name                    = string
     address_space           = optional(list(string))
     hub_resource_group_name = optional(string)
     hub_vnet_name           = optional(string)
@@ -89,8 +86,8 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -179,7 +179,6 @@ Name | Type | Description
 [`vnet_encryption`](#vnet_encryption) | `string` | Enables Azure Virtual Network encryption feature (in `AllowUnencrypted` mode by default).
 [`network_security_groups`](#network_security_groups) | `map` | Map of objects describing Network Security Groups.
 [`route_tables`](#route_tables) | `map` | Map of objects describing a Route Tables.
-[`create_subnets`](#create_subnets) | `bool` | Controls subnet creation.
 [`subnets`](#subnets) | `map` | Map of objects describing subnets to manage.
 
 ### Outputs
@@ -470,37 +469,17 @@ Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-#### create_subnets
-
-Controls subnet creation.
-  
-Possible variants:
-
-- `true`  - create subnets described in `var.subnets`.
-- `false` - source subnets described in `var.subnets`.
-  
-**Note!** \
-When this variable is `false` and `var.subnets` variable is empty, subnets management is skipped.
-
-
-Type: bool
-
-Default value: `true`
-
-<sup>[back to list](#modules-optional-inputs)</sup>
-
 #### subnets
 
 Map of objects describing subnets to manage.
   
-By the default the described subnets will be created. If however `create_subnets` is set to `false` this is just a mapping
-between the existing subnets and UDRs and NSGs that should be assigned to them.
-  
 List of available attributes of each subnet entry:
 
+- `create`                          - (`bool`, optional, defaults to `true`) controls subnet creation, subnets are created when
+                                      set to `true` or sourced when set to `false`.
 - `name`                            - (`string`, required) name of a subnet.
-- `address_prefixes`                - (`list(string)`, required when `create_subnets = true`) a list of address prefixes within
-                                      VNET's address space to assign to a created subnet.
+- `address_prefixes`                - (`list(string)`, required when `create` = true`) a list of address prefixes within VNET's
+                                      address space to assign to a created subnet.
 - `network_security_group_key`      - (`string`, optional, defaults to `null`) a key identifying an NSG defined in
                                       `network_security_groups` that should be assigned to this subnet.
 - `route_table_key`                 - (`string`, optional, defaults to `null`) a key identifying a Route Table defined in
@@ -508,6 +487,9 @@ List of available attributes of each subnet entry:
 - `enable_storage_service_endpoint` - (`bool`, optional, defaults to `false`) a flag that enables `Microsoft.Storage` service
                                       endpoint on a subnet. This is a suggested setting for the management interface when full
                                       bootstrapping using an Azure Storage Account is used.
+- `enable_cloudngfw_delegation`     - (`bool`, optional, defaults to `false`) a flag that enables subnet delegation to
+                                      `PaloAltoNetworks.Cloudngfw/firewalls` service. This is required for Cloud NGFW to work
+                                      in a VNET-based deployment.
 
 Example:
 ```hcl
@@ -535,11 +517,13 @@ Type:
 
 ```hcl
 map(object({
+    create                          = optional(bool, true)
     name                            = string
     address_prefixes                = optional(list(string), [])
     network_security_group_key      = optional(string)
     route_table_key                 = optional(string)
     enable_storage_service_endpoint = optional(bool, false)
+    enable_cloudngfw_delegation     = optional(bool, false)
   }))
 ```
 

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -38,7 +38,7 @@ locals {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet
 resource "azurerm_subnet" "this" {
-  for_each = { for k, v in var.subnets : k => v if var.create_subnets }
+  for_each = { for k, v in var.subnets : k => v if v.create }
 
   name                 = each.value.name
   resource_group_name  = var.resource_group_name
@@ -49,7 +49,7 @@ resource "azurerm_subnet" "this" {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet
 data "azurerm_subnet" "this" {
-  for_each = { for k, v in var.subnets : k => v if var.create_subnets == false }
+  for_each = { for k, v in var.subnets : k => v if !v.create }
 
   name                 = each.value.name
   resource_group_name  = var.resource_group_name
@@ -57,7 +57,7 @@ data "azurerm_subnet" "this" {
 }
 
 locals {
-  subnets = var.create_subnets ? azurerm_subnet.this : data.azurerm_subnet.this
+  subnets = merge(azurerm_subnet.this, data.azurerm_subnet.this)
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -45,6 +45,16 @@ resource "azurerm_subnet" "this" {
   virtual_network_name = local.virtual_network.name
   address_prefixes     = each.value.address_prefixes
   service_endpoints    = each.value.enable_storage_service_endpoint ? ["Microsoft.Storage"] : null
+
+  dynamic "delegation" {
+    for_each = each.value.enable_cloudngfw_delegation ? [1] : []
+    content {
+      name = "cloudngfw_delegation"
+      service_delegation {
+        name = "PaloAltoNetworks.Cloudngfw/firewalls"
+      }
+    }
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet

--- a/modules/vnet/variables.tf
+++ b/modules/vnet/variables.tf
@@ -519,35 +519,17 @@ variable "route_tables" {
   }
 }
 
-variable "create_subnets" {
-  description = <<-EOF
-  Controls subnet creation.
-  
-  Possible variants:
-
-  - `true`  - create subnets described in `var.subnets`.
-  - `false` - source subnets described in `var.subnets`.
-  
-  **Note!** \
-  When this variable is `false` and `var.subnets` variable is empty, subnets management is skipped.
-  EOF
-  default     = true
-  nullable    = false
-  type        = bool
-}
-
 variable "subnets" {
   description = <<-EOF
   Map of objects describing subnets to manage.
   
-  By the default the described subnets will be created. If however `create_subnets` is set to `false` this is just a mapping
-  between the existing subnets and UDRs and NSGs that should be assigned to them.
-  
   List of available attributes of each subnet entry:
 
+  - `create`                          - (`bool`, optional, defaults to `true`) controls subnet creation, subnets are created when
+                                        set to `true` or sourced when set to `false`.
   - `name`                            - (`string`, required) name of a subnet.
-  - `address_prefixes`                - (`list(string)`, required when `create_subnets = true`) a list of address prefixes within
-                                        VNET's address space to assign to a created subnet.
+  - `address_prefixes`                - (`list(string)`, required when `create` = true`) a list of address prefixes within VNET's
+                                        address space to assign to a created subnet.
   - `network_security_group_key`      - (`string`, optional, defaults to `null`) a key identifying an NSG defined in
                                         `network_security_groups` that should be assigned to this subnet.
   - `route_table_key`                 - (`string`, optional, defaults to `null`) a key identifying a Route Table defined in
@@ -580,6 +562,7 @@ variable "subnets" {
   default     = {}
   nullable    = false
   type = map(object({
+    create                          = optional(bool, true)
     name                            = string
     address_prefixes                = optional(list(string), [])
     network_security_group_key      = optional(string)
@@ -590,6 +573,12 @@ variable "subnets" {
     condition     = length([for _, v in var.subnets : v.name]) == length(distinct([for _, v in var.subnets : v.name]))
     error_message = <<-EOF
     The `name` property has to be unique.
+    EOF
+  }
+  validation { # create, address_prefixes
+    condition     = alltrue(flatten([for _, snet in var.subnets : [snet.create ? length(snet.address_prefixes) > 0 : true]]))
+    error_message = <<-EOF
+    When subnet is created, the `address_prefixes` list must not be empty.
     EOF
   }
   validation { # address_prefixes

--- a/modules/vnet/variables.tf
+++ b/modules/vnet/variables.tf
@@ -537,6 +537,9 @@ variable "subnets" {
   - `enable_storage_service_endpoint` - (`bool`, optional, defaults to `false`) a flag that enables `Microsoft.Storage` service
                                         endpoint on a subnet. This is a suggested setting for the management interface when full
                                         bootstrapping using an Azure Storage Account is used.
+  - `enable_cloudngfw_delegation`     - (`bool`, optional, defaults to `false`) a flag that enables subnet delegation to
+                                        `PaloAltoNetworks.Cloudngfw/firewalls` service. This is required for Cloud NGFW to work
+                                        in a VNET-based deployment.
 
   Example:
   ```hcl
@@ -568,6 +571,7 @@ variable "subnets" {
     network_security_group_key      = optional(string)
     route_table_key                 = optional(string)
     enable_storage_service_endpoint = optional(bool, false)
+    enable_cloudngfw_delegation     = optional(bool, false)
   }))
   validation { # name
     condition     = length([for _, v in var.subnets : v.name]) == length(distinct([for _, v in var.subnets : v.name]))

--- a/tests/appgw/README.md
+++ b/tests/appgw/README.md
@@ -71,38 +71,38 @@ A map defining VNETs.
 
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
-- `create_virtual_network`  - (`bool`, optional, defaults to `false`) when set to `true` will create a VNET,
-                              `false` will source an existing VNET.
-- `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false`
-                              this should be a full resource name, including prefixes.
-- `address_space`           - (`list(string)`, required when `create_virtual_network = false`) a list of CIDRs
-                              for a newly created VNET.
+- `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
+                              an existing VNET.
+- `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
+                              full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
+- `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group
-                              in which the VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optinoal, defaults to `true`) if `true`,
-                              create Subnets inside the Virtual Network, otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
+- `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
+                              set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
+                              disabled.
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
-    name                   = string
     create_virtual_network = optional(bool, true)
-    address_space          = optional(list(string), [])
-    dns_servers            = optional(list(string))
+    name                   = string
     resource_group_name    = optional(string)
+    address_space          = optional(list(string))
+    dns_servers            = optional(list(string))
+    vnet_encryption        = optional(string)
     network_security_groups = optional(map(object({
-      name     = string
-      location = optional(string)
+      name = string
       rules = optional(map(object({
         name                         = string
         priority                     = number
@@ -120,22 +120,23 @@ map(object({
       })), {})
     })), {})
     route_tables = optional(map(object({
-      name     = string
-      location = optional(string)
+      name                          = string
+      bgp_route_propagation_enabled = optional(bool)
       routes = map(object({
-        name                   = string
-        address_prefix         = string
-        next_hop_type          = string
-        next_hop_in_ip_address = optional(string)
+        name                = string
+        address_prefix      = string
+        next_hop_type       = string
+        next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```

--- a/tests/appgw/main.tf
+++ b/tests/appgw/main.tf
@@ -48,8 +48,7 @@ module "vnet" {
   address_space = each.value.address_space
   dns_servers   = each.value.dns_servers
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/tests/appgw/variables.tf
+++ b/tests/appgw/variables.tf
@@ -53,34 +53,34 @@ variable "vnets" {
 
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
-  - `create_virtual_network`  - (`bool`, optional, defaults to `false`) when set to `true` will create a VNET,
-                                `false` will source an existing VNET.
-  - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false`
-                                this should be a full resource name, including prefixes.
-  - `address_space`           - (`list(string)`, required when `create_virtual_network = false`) a list of CIDRs
-                                for a newly created VNET.
+  - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
+                                an existing VNET.
+  - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
+                                full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
+  - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group
-                                in which the VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optinoal, defaults to `true`) if `true`,
-                                create Subnets inside the Virtual Network, otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
+  - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
+                                set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
+                                disabled.
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
-    name                   = string
     create_virtual_network = optional(bool, true)
-    address_space          = optional(list(string), [])
-    dns_servers            = optional(list(string))
+    name                   = string
     resource_group_name    = optional(string)
+    address_space          = optional(list(string))
+    dns_servers            = optional(list(string))
+    vnet_encryption        = optional(string)
     network_security_groups = optional(map(object({
-      name     = string
-      location = optional(string)
+      name = string
       rules = optional(map(object({
         name                         = string
         priority                     = number
@@ -98,22 +98,23 @@ variable "vnets" {
       })), {})
     })), {})
     route_tables = optional(map(object({
-      name     = string
-      location = optional(string)
+      name                          = string
+      bgp_route_propagation_enabled = optional(bool)
       routes = map(object({
-        name                   = string
-        address_prefix         = string
-        next_hop_type          = string
-        next_hop_in_ip_address = optional(string)
+        name                = string
+        address_prefix      = string
+        next_hop_type       = string
+        next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }

--- a/tests/virtual_network_gateway/README.md
+++ b/tests/virtual_network_gateway/README.md
@@ -72,37 +72,39 @@ Type: string
 #### vnets
 
 A map defining VNETs.
-  
+
 For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
 - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                               an existing VNET.
 - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                               full resource name, including prefixes.
+- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                              VNET will reside or is sourced from.
 - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
 - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                               default Azure DNS is used).
-- `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                              VNET will reside or is sourced from.
-- `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                              otherwise use source existing subnets.
-- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                              [VNET module documentation](../../modules/vnet/README.md#subnets).
+- `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
+                              set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
+                              disabled.
 - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
 - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                               [VNET module documentation](../../modules/vnet/README.md#route_tables).
+- `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                              [VNET module documentation](../../modules/vnet/README.md#subnets).
 
 
 Type: 
 
 ```hcl
 map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
+    vnet_encryption        = optional(string)
     network_security_groups = optional(map(object({
       name = string
       rules = optional(map(object({
@@ -123,7 +125,7 @@ map(object({
     })), {})
     route_tables = optional(map(object({
       name                          = string
-      disable_bgp_route_propagation = optional(bool)
+      bgp_route_propagation_enabled = optional(bool)
       routes = map(object({
         name                = string
         address_prefix      = string
@@ -131,13 +133,14 @@ map(object({
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 ```

--- a/tests/virtual_network_gateway/main.tf
+++ b/tests/virtual_network_gateway/main.tf
@@ -36,8 +36,7 @@ module "vnet" {
   address_space = each.value.address_space
   dns_servers   = each.value.dns_servers
 
-  create_subnets = each.value.create_subnets
-  subnets        = each.value.subnets
+  subnets = each.value.subnets
 
   network_security_groups = {
     for k, v in each.value.network_security_groups : k => merge(v, { name = "${var.name_prefix}${v.name}" })

--- a/tests/virtual_network_gateway/variables.tf
+++ b/tests/virtual_network_gateway/variables.tf
@@ -51,33 +51,35 @@ variable "tags" {
 variable "vnets" {
   description = <<-EOF
   A map defining VNETs.
-  
+
   For detailed documentation on each property refer to [module documentation](../../modules/vnet/README.md)
 
   - `create_virtual_network`  - (`bool`, optional, defaults to `true`) when set to `true` will create a VNET, `false` will source
                                 an existing VNET.
   - `name`                    - (`string`, required) a name of a VNET. In case `create_virtual_network = false` this should be a
                                 full resource name, including prefixes.
+  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
+                                VNET will reside or is sourced from.
   - `address_space`           - (`list`, required when `create_virtual_network = false`) a list of CIDRs for a newly created VNET.
   - `dns_servers`             - (`list`, optional, defaults to module defaults) a list of IP addresses of custom DNS servers (by
                                 default Azure DNS is used).
-  - `resource_group_name`     - (`string`, optional, defaults to current RG) a name of an existing Resource Group in which the
-                                VNET will reside or is sourced from.
-  - `create_subnets`          - (`bool`, optional, defaults to `true`) if `true`, create Subnets inside the Virtual Network,
-                                otherwise use source existing subnets.
-  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
-                                [VNET module documentation](../../modules/vnet/README.md#subnets).
+  - `vnet_encryption`         - (`string`, optional, defaults to module default) enables Azure Virtual Network Encryption when
+                                set, only possible value at the moment is `AllowUnencrypted`. When set to `null`, the feature is 
+                                disabled.
   - `network_security_groups` - (`map`, optional) map of Network Security Groups to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#network_security_groups).
   - `route_tables`            - (`map`, optional) map of Route Tables to create, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
+  - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
+                                [VNET module documentation](../../modules/vnet/README.md#subnets).
   EOF
   type = map(object({
+    create_virtual_network = optional(bool, true)
     name                   = string
     resource_group_name    = optional(string)
-    create_virtual_network = optional(bool, true)
     address_space          = optional(list(string))
     dns_servers            = optional(list(string))
+    vnet_encryption        = optional(string)
     network_security_groups = optional(map(object({
       name = string
       rules = optional(map(object({
@@ -98,7 +100,7 @@ variable "vnets" {
     })), {})
     route_tables = optional(map(object({
       name                          = string
-      disable_bgp_route_propagation = optional(bool)
+      bgp_route_propagation_enabled = optional(bool)
       routes = map(object({
         name                = string
         address_prefix      = string
@@ -106,13 +108,14 @@ variable "vnets" {
         next_hop_ip_address = optional(string)
       }))
     })), {})
-    create_subnets = optional(bool, true)
     subnets = optional(map(object({
+      create                          = optional(bool, true)
       name                            = string
       address_prefixes                = optional(list(string), [])
       network_security_group_key      = optional(string)
       route_table_key                 = optional(string)
-      enable_storage_service_endpoint = optional(bool, false)
+      enable_storage_service_endpoint = optional(bool)
+      enable_cloudngfw_delegation     = optional(bool)
     })), {})
   }))
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces 2 new functionalities to the VNET module:
- capability to source existing subnets on a per-subnet basis (not all or nothing like previously)
- subnet delegation to CloudNGFW service (required for VNET-based CloudNGFW deployment)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- need for sourcing some of the subnets and creating rest of them within the same VNET
- CloudNGFW support

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By deploying chosen examples manually.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
