### PR TITLE
fix: Revert terraform_docs version to v1.94.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - --args=--only=terraform_workspace_remote
     id: terraform_tflint
   repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.96.1
+  rev: v1.94.2
 - hooks:
   - args:
     - --compact


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR reverts Terraform Docs version to latest working properly (`v1.94.2`)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Terraform Docs was not working properly on version `1.96.1` (new READMEs were not generated despite changes in the code)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

On local workstation

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
