### PR TITLE
fix: Remove bootstrap_storages option from the testing pipeline

### DIFF
--- a/examples/dedicated_vmseries/main_test.go
+++ b/examples/dedicated_vmseries/main_test.go
@@ -1,34 +1,17 @@
 package dedicated_vmseries
 
 import (
-	"fmt"
-	"log"
-	"os"
 	"testing"
 
-	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+
+	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
 )
 
 func CreateTerraformOptions(t *testing.T) *terraform.Options {
 	// prepare random prefix
 	randomNames, _ := testskeleton.GenerateTerraformVarsInfo("azure")
-	// storageDefinition := fmt.Sprintf("{ bootstrap = { name = \"%s\", public_snet_key = \"public\", private_snet_key = \"private\", intranet_cidr = \"10.0.0.0/25\"} }", randomNames.AzureStorageAccountName)
-	storageDefinition := fmt.Sprintf("{ bootstrap = { name = \"%s\" }}", randomNames.AzureStorageAccountName)
-
-	// copy the init-cfg.sample.txt file to init-cfg.txt for test purposes
-	_, err := os.Stat("files/init-cfg.txt")
-	if err != nil {
-		buff, err := os.ReadFile("files/init-cfg.sample.txt")
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = os.WriteFile("files/init-cfg.txt", buff, 0644)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	// define options for Terraform
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -37,7 +20,6 @@ func CreateTerraformOptions(t *testing.T) *terraform.Options {
 		Vars: map[string]interface{}{
 			"name_prefix":         randomNames.NamePrefix,
 			"resource_group_name": randomNames.AzureResourceGroupName,
-			"bootstrap_storages":  storageDefinition,
 		},
 		Logger:               logger.Default,
 		Lock:                 true,

--- a/examples/gwlb_with_vmseries/main_test.go
+++ b/examples/gwlb_with_vmseries/main_test.go
@@ -1,33 +1,17 @@
 package gwlb_with_vmseries
 
 import (
-	"fmt"
-	"log"
-	"os"
 	"testing"
 
-	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+
+	"github.com/PaloAltoNetworks/terraform-modules-swfw-tests-skeleton/pkg/testskeleton"
 )
 
 func CreateTerraformOptions(t *testing.T) *terraform.Options {
 	// prepare random prefix
 	randomNames, _ := testskeleton.GenerateTerraformVarsInfo("azure")
-	storageDefinition := fmt.Sprintf("{ bootstrap = { name = \"%s\" } }", randomNames.AzureStorageAccountName)
-
-	// copy the init-cfg.sample.txt file to init-cfg.txt for test purposes
-	_, err := os.Stat("files/init-cfg.txt")
-	if err != nil {
-		buff, err := os.ReadFile("files/init-cfg.sample.txt")
-		if err != nil {
-			log.Fatal(err)
-		}
-		err = os.WriteFile("files/init-cfg.txt", buff, 0644)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
 
 	// define options for Terraform
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
@@ -36,7 +20,6 @@ func CreateTerraformOptions(t *testing.T) *terraform.Options {
 		Vars: map[string]interface{}{
 			"name_prefix":         randomNames.NamePrefix,
 			"resource_group_name": randomNames.AzureResourceGroupName,
-			"bootstrap_storages":  storageDefinition,
 		},
 		Logger:               logger.Default,
 		Lock:                 true,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR removes creating a `bootstrap_storages` option in the Terratest GO files within the examples in order to fix the testing pipelines.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We no longer use full bootstrap as a default bootstrap option in any of the examples.
Release CI is failing because of that.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
