### PR TITLE
feat: Bring back public IPs to mgmt interfaces

### DIFF
--- a/examples/common_vmseries/example.tfvars
+++ b/examples/common_vmseries/example.tfvars
@@ -302,7 +302,7 @@ vmseries = {
       {
         name             = "vm01-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name                    = "vm01-public"
@@ -328,7 +328,7 @@ vmseries = {
       {
         name             = "vm02-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name                    = "vm02-public"

--- a/examples/common_vmseries_and_autoscale/example.tfvars
+++ b/examples/common_vmseries_and_autoscale/example.tfvars
@@ -311,7 +311,7 @@ scale_sets = {
       {
         name             = "management"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name                    = "public"

--- a/examples/dedicated_vmseries/example.tfvars
+++ b/examples/dedicated_vmseries/example.tfvars
@@ -245,7 +245,7 @@ vmseries = {
       {
         name             = "vm-in-01-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name              = "vm-in-01-public"
@@ -309,7 +309,7 @@ vmseries = {
       {
         name             = "vm-in-02-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name              = "vm-in-02-public"
@@ -372,7 +372,7 @@ vmseries = {
       {
         name             = "vm-obew-01-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name             = "vm-obew-01-public"
@@ -436,7 +436,7 @@ vmseries = {
       {
         name             = "vm-obew-02-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name             = "vm-obew-02-public"

--- a/examples/gwlb_with_vmseries/example.tfvars
+++ b/examples/gwlb_with_vmseries/example.tfvars
@@ -201,7 +201,7 @@ vmseries = {
       {
         name             = "vm01-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name             = "vm01-data"
@@ -221,7 +221,7 @@ vmseries = {
       {
         name             = "vm02-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       },
       {
         name             = "vm02-data"

--- a/examples/standalone_panorama/example.tfvars
+++ b/examples/standalone_panorama/example.tfvars
@@ -69,7 +69,7 @@ panoramas = {
         name               = "management"
         subnet_key         = "panorama"
         private_ip_address = "10.1.0.10"
-        create_public_ip   = false
+        create_public_ip   = true
       }
     ]
     logging_disks = {

--- a/examples/standalone_vmseries/example.tfvars
+++ b/examples/standalone_vmseries/example.tfvars
@@ -120,7 +120,7 @@ vmseries = {
       {
         name             = "vm-mgmt"
         subnet_key       = "management"
-        create_public_ip = false
+        create_public_ip = true
       }
     ]
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds public IP addresses to mgmt interfaces of vmseries and panorama in examples.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Rollback PR #109 

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
