### PR TITLE
fix: Make LB Frontends zone-redundant in examples

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -575,7 +575,7 @@ Following properties are available:
 - `name`                    - (`string`, required) a name of the Load Balancer.
 - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                               map that stores the Subnet described by `subnet_key`.
-- `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+- `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                               configurations.
 - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
 - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -611,7 +611,7 @@ Type:
 map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1328,7 +1328,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1449,7 +1449,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -271,7 +271,7 @@ variable "load_balancers" {
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -305,7 +305,7 @@ variable "load_balancers" {
   type = map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1038,7 +1038,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1157,7 +1157,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -602,7 +602,7 @@ Following properties are available:
 - `name`                    - (`string`, required) a name of the Load Balancer.
 - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                               map that stores the Subnet described by `subnet_key`.
-- `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+- `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                               configurations.
 - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
 - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -638,7 +638,7 @@ Type:
 map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1382,7 +1382,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1503,7 +1503,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -271,7 +271,7 @@ variable "load_balancers" {
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -305,7 +305,7 @@ variable "load_balancers" {
   type = map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1034,7 +1034,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1153,7 +1153,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -579,7 +579,7 @@ Following properties are available:
 - `name`                    - (`string`, required) a name of the Load Balancer.
 - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                               map that stores the Subnet described by `subnet_key`.
-- `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+- `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                               configurations.
 - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
 - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -615,7 +615,7 @@ Type:
 map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1332,7 +1332,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1453,7 +1453,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -271,7 +271,7 @@ variable "load_balancers" {
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -305,7 +305,7 @@ variable "load_balancers" {
   type = map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1038,7 +1038,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1157,7 +1157,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -596,7 +596,7 @@ Following properties are available:
 - `name`                    - (`string`, required) a name of the Load Balancer.
 - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                               map that stores the Subnet described by `subnet_key`.
-- `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+- `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                               configurations.
 - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
 - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -632,7 +632,7 @@ Type:
 map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1376,7 +1376,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1497,7 +1497,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -271,7 +271,7 @@ variable "load_balancers" {
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -305,7 +305,7 @@ variable "load_balancers" {
   type = map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1034,7 +1034,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1153,7 +1153,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -978,7 +978,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1099,7 +1099,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -759,7 +759,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -878,7 +878,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -513,7 +513,7 @@ Following properties are available:
 - `name`                    - (`string`, required) a name of the Load Balancer.
 - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                               map that stores the Subnet described by `subnet_key`.
-- `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+- `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                               configurations.
 - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
 - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -549,7 +549,7 @@ Type:
 map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1266,7 +1266,7 @@ Following properties are supported:
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional) a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1387,7 +1387,7 @@ map(object({
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -271,7 +271,7 @@ variable "load_balancers" {
   - `name`                    - (`string`, required) a name of the Load Balancer.
   - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                 map that stores the Subnet described by `subnet_key`.
-  - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+  - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                 configurations.
   - `backend_name`            - (`string`, optional, defaults to "vmseries_backend") a name of the backend pool to create.
   - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -305,7 +305,7 @@ variable "load_balancers" {
   type = map(object({
     name         = string
     vnet_key     = optional(string)
-    zones        = optional(list(string))
+    zones        = optional(list(string), ["1", "2", "3"])
     backend_name = optional(string, "vmseries_backend")
     health_probes = optional(map(object({
       name                = string
@@ -1038,7 +1038,7 @@ variable "test_infrastructure" {
     - `name`                    - (`string`, required) a name of the Load Balancer.
     - `vnet_key`                - (`string`, optional, defaults to `null`) a key pointing to a VNET definition in the `var.vnets`
                                   map that stores the Subnet described by `subnet_key`.
-    - `zones`                   - (`list`, optional, defaults to module default) a list of zones for Load Balancer's frontend IP
+    - `zones`                   - (`list`, optional, defaults to ["1", "2", "3"]) a list of zones for Load Balancer's frontend IP
                                   configurations.
     - `backend_name`            - (`string`, optional) a name of the backend pool to create.
     - `health_probes`           - (`map`, optional, defaults to `null`) a map defining health probes that will be used by load
@@ -1157,7 +1157,7 @@ variable "test_infrastructure" {
     load_balancers = optional(map(object({
       name         = string
       vnet_key     = optional(string)
-      zones        = optional(list(string))
+      zones        = optional(list(string), ["1", "2", "3"])
       backend_name = optional(string)
       health_probes = optional(map(object({
         name                = string


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds a default value of `["1", "2", "3"]` to `zones` property in `load_balancers` map across all examples.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Default value was not inherited from the `loadbalancer` module and non-zonal LB frontends were created, instead of zone-redundant LB frontends as intended.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed one of the examples manually.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
