### PR TITLE
fix(bootstrap): Replace deprecated storage_account_name property

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -132,11 +132,11 @@ details refer to the [var.file_shares](#file_shares) variable documentation.
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 4.9
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 4.9
 
 
 

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -55,18 +55,18 @@ locals {
 resource "azurerm_storage_share" "this" {
   for_each = var.file_shares_configuration.create_file_shares ? var.file_shares : {}
 
-  name                 = each.value.name
-  storage_account_name = local.storage_account.name
-  quota                = coalesce(each.value.quota, var.file_shares_configuration.quota)
-  access_tier          = coalesce(each.value.access_tier, var.file_shares_configuration.access_tier)
+  name               = each.value.name
+  storage_account_id = local.storage_account.id
+  quota              = coalesce(each.value.quota, var.file_shares_configuration.quota)
+  access_tier        = coalesce(each.value.access_tier, var.file_shares_configuration.access_tier)
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_share
 data "azurerm_storage_share" "this" {
   for_each = var.file_shares_configuration.create_file_shares ? {} : var.file_shares
 
-  name                 = each.value.name
-  storage_account_name = local.storage_account.name
+  name               = each.value.name
+  storage_account_id = local.storage_account.id
 
   lifecycle {
     precondition {

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.9"
     }
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR replaces deprecated `storage_account_name` property with `storage_account_id` property within the `azurerm_storage_share` resource.

New property was introduced in `azurerm` provider version **4.9** so the module's version constraints got bumped.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Property got deprecated.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deploying locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
