### PR TITLE
feat: Add new vnet properties to test_infrastructure variable in examples

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1390,6 +1390,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -1098,6 +1098,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -1444,6 +1444,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -1094,6 +1094,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1394,6 +1394,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -1098,6 +1098,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -1438,6 +1438,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -1094,6 +1094,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -1040,6 +1040,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -819,6 +819,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -1328,6 +1328,8 @@ map(object({
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -1098,6 +1098,8 @@ variable "test_infrastructure" {
       name                    = string
       address_space           = optional(list(string))
       dns_servers             = optional(list(string))
+      vnet_encryption         = optional(string)
+      ddos_protection_plan_id = optional(string)
       hub_resource_group_name = optional(string)
       hub_vnet_name           = string
       network_security_groups = optional(map(object({


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds 2 missing vnet properties (`vnet_encryption` & `ddos_protection_plan_id`) to `test_infrastructure` variable in all examples.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's already available in the module but was not populated into the examples.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally by deploying one of the examples.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
