### PR TITLE
fix(virtual_network_gateway): Active/Passive VNG creation fix

### DIFF
--- a/modules/virtual_network_gateway/main.tf
+++ b/modules/virtual_network_gateway/main.tf
@@ -1,6 +1,6 @@
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip
 resource "azurerm_public_ip" "this" {
-  for_each = { for k, v in var.ip_configurations : k => v if v.create_public_ip }
+  for_each = { for k, v in var.ip_configurations : k => v if try(v.create_public_ip, false) }
 
   resource_group_name = var.resource_group_name
   location            = var.region
@@ -15,7 +15,8 @@ resource "azurerm_public_ip" "this" {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip
 data "azurerm_public_ip" "this" {
-  for_each = { for k, v in var.ip_configurations : k => v if !v.create_public_ip && v.public_ip_name != null }
+  for_each = { for k, v in var.ip_configurations : k => v
+  if !try(v.create_public_ip, false) && try(v.public_ip_name, null) != null }
 
   name                = each.value.public_ip_name
   resource_group_name = coalesce(each.value.public_ip_resource_group_name, var.resource_group_name)


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds error handling to `azurerm_public_ip` resource `for_each` conditions.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Module was failing to create a Virtual Network Gateway in Active/Passive mode because the `for_each` conditions for secondary public IP resource failed.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
