### PR TITLE
docs: Correct terraform output names in examples READMEs

### DIFF
--- a/examples/common_vmseries_and_autoscale/.header.md
+++ b/examples/common_vmseries_and_autoscale/.header.md
@@ -191,13 +191,13 @@ To retrieve the initial credentials run:
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 ### Cleanup

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -191,13 +191,13 @@ To retrieve the initial credentials run:
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 ### Cleanup

--- a/examples/dedicated_vmseries/.header.md
+++ b/examples/dedicated_vmseries/.header.md
@@ -145,13 +145,13 @@ Firewalls in this example are configured with password authentication. To retrie
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips`:

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -145,13 +145,13 @@ Firewalls in this example are configured with password authentication. To retrie
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips`:

--- a/examples/dedicated_vmseries_and_autoscale/.header.md
+++ b/examples/dedicated_vmseries_and_autoscale/.header.md
@@ -185,13 +185,13 @@ To retrieve the initial credentials run:
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 ### Cleanup

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -185,13 +185,13 @@ To retrieve the initial credentials run:
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 ### Cleanup

--- a/examples/gwlb_with_vmseries/.header.md
+++ b/examples/gwlb_with_vmseries/.header.md
@@ -88,13 +88,13 @@ Firewalls in this example are configured with password authentication. To retrie
 - for username:
 
 ```bash
-terraform output username
+terraform output usernames
 ```
 
 - for password:
 
 ```bash
-terraform output password
+terraform output passwords
 ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips` output:

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -88,13 +88,13 @@ Firewalls in this example are configured with password authentication. To retrie
 - for username:
 
 ```bash
-terraform output username
+terraform output usernames
 ```
 
 - for password:
 
 ```bash
-terraform output password
+terraform output passwords
 ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips` output:

--- a/examples/standalone_vmseries/.header.md
+++ b/examples/standalone_vmseries/.header.md
@@ -85,13 +85,13 @@ Firewall in this example is configured with password authentication. To retrieve
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips`:

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -85,13 +85,13 @@ Firewall in this example is configured with password authentication. To retrieve
 - for username:
 
   ```bash
-  terraform output username
+  terraform output usernames
   ```
 
 - for password:
 
   ```bash
-  terraform output password
+  terraform output passwords
   ```
 
 The management public IP addresses are available in the `vmseries_mgmt_ips`:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR updates terraform output names in examples READMEs:
`username` -> `usernames`
`password` -> `passwords`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some terraform output commands listed in the README didn't work.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
