### PR TITLE
feat(panorama): Disable access from public networks on Panorama data disks

### DIFF
--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -121,14 +121,15 @@ resource "azurerm_linux_virtual_machine" "this" {
 resource "azurerm_managed_disk" "this" {
   for_each = var.logging_disks
 
-  name                 = each.value.name
-  location             = var.region
-  resource_group_name  = var.resource_group_name
-  storage_account_type = each.value.disk_type
-  create_option        = "Empty"
-  disk_size_gb         = each.value.size
-  zone                 = var.virtual_machine.zone != null && var.virtual_machine.zone != "" ? var.virtual_machine.zone : null
-  tags                 = var.tags
+  name                          = each.value.name
+  location                      = var.region
+  resource_group_name           = var.resource_group_name
+  storage_account_type          = each.value.disk_type
+  create_option                 = "Empty"
+  disk_size_gb                  = each.value.size
+  zone                          = var.virtual_machine.zone != null && var.virtual_machine.zone != "" ? var.virtual_machine.zone : null
+  public_network_access_enabled = false
+  tags                          = var.tags
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR disables public network access on managed disks within `panorama` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

CKV_AZURE_251: "Ensure Azure Virtual Machine disks are configured without public network access"

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally with `standalone_panorama` example.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
