### PR TITLE
fix: 130: use azurerm_storage_share...url instead of id

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -101,7 +101,7 @@ resource "azurerm_storage_share_directory" "this" {
   }
 
   name             = each.value.folder_name
-  storage_share_id = local.file_shares[each.value.share_key].id
+  storage_share_id = local.file_shares[each.value.share_key].url
 }
 
 


### PR DESCRIPTION
## Description
azure changes the way that references to among share and directories are made. The way the bootstrap module currently uses them results in an error #130 
context:
https://github.com/hashicorp/terraform-provider-azurerm/issues/28032
https://github.com/hashicorp/terraform-provider-azurerm/pull/28457
Most likely in azurerm provider 5.0 this will require further update (use `storage_share_url`)

## Motivation and Context

fixes #130 

## How Has This Been Tested?

```
module "bs" {
  source = "github.com/rweglarz/terraform-azurerm-swfw-modules//modules/bootstrap?ref=130-fix-bootstrap"

  name                 = "${var.name}${random_id.this.hex}"
  resource_group_name  = azurerm_resource_group.this.name
  region               = azurerm_resource_group.this.location
  file_shares = {
    fw1 = {
      name = "fw1"
      "fw1/init-cfg.txt" = "config/init-cfg.txt"
    }
  }
}

```


## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [-] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [-] I have added tests to cover my changes if appropriate.
- [?] All new and existing tests passed.
