### PR TITLE
fix(vnet): Fix port ranges variables validation in vnet module

### DIFF
--- a/modules/vnet/variables.tf
+++ b/modules/vnet/variables.tf
@@ -275,7 +275,7 @@ variable "network_security_groups" {
     condition = alltrue(flatten([
       for _, nsg in var.network_security_groups : [
         for _, rule in nsg.rules :
-        can(regex("^\\*$|^\\d{1,4}[0-5]?(\\-\\d{1,4}[0-5])?$", rule.source_port_range))
+        can(regex("^\\*$|^\\d{1,5}(\\-\\d{1,5})?$", rule.source_port_range))
         if rule.source_port_range != null
       ]
     ]))
@@ -289,7 +289,7 @@ variable "network_security_groups" {
       for _, nsg in var.network_security_groups : [
         for _, rule in nsg.rules : [
           for _, range in coalesce(rule.source_port_ranges, []) :
-          can(regex("^\\d{1,4}[0-5]?(\\-\\d{1,4}[0-5])?$", range))
+          can(regex("^\\d{1,5}(\\-\\d{1,5})?$", range))
         ]
       ]
     ]))
@@ -313,7 +313,7 @@ variable "network_security_groups" {
     condition = alltrue(flatten([
       for _, nsg in var.network_security_groups : [
         for _, rule in nsg.rules :
-        can(regex("^\\*$|^\\d{1,4}[0-5]?(\\-\\d{1,4}[0-5])?$", rule.destination_port_range))
+        can(regex("^\\*$|^\\d{1,5}(\\-\\d{1,5})?$", rule.destination_port_range))
         if rule.destination_port_range != null
       ]
     ]))
@@ -327,7 +327,7 @@ variable "network_security_groups" {
       for _, nsg in var.network_security_groups : [
         for _, rule in nsg.rules : [
           for _, range in coalesce(rule.destination_port_ranges, []) :
-          can(regex("^\\d{1,4}[0-5]?(\\-\\d{1,4}[0-5])?$", range))
+          can(regex("^\\d{1,5}(\\-\\d{1,5})?$", range))
         ]
       ]
     ]))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes port ranges variables validation in the vnet `module` by simplifying the regexp expression.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#133 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally ran the validations.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
