### PR TITLE
feat(vmseries): Allow customization of IP configuration name in Azure VM interface

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -1265,6 +1265,7 @@ map(object({
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/common_vmseries/main.tf
+++ b/examples/common_vmseries/main.tf
@@ -445,9 +445,10 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name             = "${var.name_prefix}${v.name}"
-    subnet_id        = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    create_public_ip = v.create_public_ip
+    name                  = "${var.name_prefix}${v.name}"
+    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configuration_name = v.ip_configuration_name
+    create_public_ip      = v.create_public_ip
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -940,6 +940,7 @@ variable "vmseries" {
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -1269,6 +1269,7 @@ map(object({
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/dedicated_vmseries/main.tf
+++ b/examples/dedicated_vmseries/main.tf
@@ -445,9 +445,10 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name             = "${var.name_prefix}${v.name}"
-    subnet_id        = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    create_public_ip = v.create_public_ip
+    name                  = "${var.name_prefix}${v.name}"
+    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configuration_name = v.ip_configuration_name
+    create_public_ip      = v.create_public_ip
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -940,6 +940,7 @@ variable "vmseries" {
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -913,6 +913,7 @@ map(object({
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/gwlb_with_vmseries/main.tf
+++ b/examples/gwlb_with_vmseries/main.tf
@@ -321,9 +321,10 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name             = "${var.name_prefix}${v.name}"
-    subnet_id        = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    create_public_ip = v.create_public_ip
+    name                  = "${var.name_prefix}${v.name}"
+    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configuration_name = v.ip_configuration_name
+    create_public_ip      = v.create_public_ip
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name

--- a/examples/gwlb_with_vmseries/variables.tf
+++ b/examples/gwlb_with_vmseries/variables.tf
@@ -660,6 +660,7 @@ variable "vmseries" {
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -1203,6 +1203,7 @@ map(object({
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/examples/standalone_vmseries/main.tf
+++ b/examples/standalone_vmseries/main.tf
@@ -445,9 +445,10 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name             = "${var.name_prefix}${v.name}"
-    subnet_id        = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    create_public_ip = v.create_public_ip
+    name                  = "${var.name_prefix}${v.name}"
+    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configuration_name = v.ip_configuration_name
+    create_public_ip      = v.create_public_ip
     public_ip_name = v.create_public_ip ? "${
       var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
     }" : v.public_ip_name

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -940,6 +940,7 @@ variable "vmseries" {
     interfaces = list(object({
       name                          = string
       subnet_key                    = string
+      ip_configuration_name         = optional(string)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -270,6 +270,7 @@ Following configuration options are available:
 
 - `name`                          - (`string`, required) the interface name.
 - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
+- `ip_configuration_name`         - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
 - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                     skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                     to change as long as the VM is running. Any stop/deallocate/restart operation might cause
@@ -323,6 +324,7 @@ Type:
 list(object({
     name                          = string
     subnet_id                     = string
+    ip_configuration_name         = optional(string, "primary")
     create_public_ip              = optional(bool, false)
     public_ip_name                = optional(string)
     public_ip_resource_group_name = optional(string)

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_network_interface" "this" {
   tags                           = var.tags
 
   ip_configuration {
-    name                          = "primary"
+    name                          = each.value.ip_configuration_name
     subnet_id                     = each.value.subnet_id
     private_ip_address_allocation = each.value.private_ip_address != null ? "Static" : "Dynamic"
     private_ip_address            = each.value.private_ip_address

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -200,6 +200,7 @@ variable "interfaces" {
 
   - `name`                          - (`string`, required) the interface name.
   - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
+  - `ip_configuration_name`         - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
   - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                       skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                       to change as long as the VM is running. Any stop/deallocate/restart operation might cause
@@ -249,6 +250,7 @@ variable "interfaces" {
   type = list(object({
     name                          = string
     subnet_id                     = string
+    ip_configuration_name         = optional(string, "primary")
     create_public_ip              = optional(bool, false)
     public_ip_name                = optional(string)
     public_ip_resource_group_name = optional(string)


### PR DESCRIPTION
## Description

This PR introduces the ability to modify the IP configuration name in the Azure VM network interface, providing greater flexibility in network configuration.

## Motivation and Context

Currently, the IP configuration name in the Azure VM network interface is hardcoded, limiting flexibility in network setups. 

## How Has This Been Tested?

Deployed manually.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
