### PR TITLE
ci: Pin remaining GitHub Actions

### DIFF
--- a/.github/actions/sub_cleanup/action.yml
+++ b/.github/actions/sub_cleanup/action.yml
@@ -11,7 +11,7 @@ runs:
   steps:
 
     - name: login to Azure
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         client-id: ${{ env.ARM_CLIENT_ID }}
         tenant-id: ${{ env.ARM_TENANT_ID }}

--- a/.github/actions/terratest/action.yml
+++ b/.github/actions/terratest/action.yml
@@ -22,18 +22,18 @@ runs:
   steps:
 
     - name: setup Terraform
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
       with:
         terraform_version: ${{ inputs.tf_version }}
         terraform_wrapper: false
 
     - name: setup Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
       with:
         go-version: '1.21'
 
     - name: login to Azure
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         client-id: ${{ env.ARM_CLIENT_ID }}
         tenant-id: ${{ env.ARM_TENANT_ID }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: get PR head branch
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         id: pr
         with:
           result-encoding: string
@@ -82,7 +82,7 @@ jobs:
 
       - name: Edit comment with error message
         if: steps.scd.outputs.error-message
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ github.event.comment.id }}
           body: |

--- a/.github/workflows/sca-command.yml
+++ b/.github/workflows/sca-command.yml
@@ -39,7 +39,7 @@ jobs:
       paths: ${{ steps.paths_reformat.outputs.paths }}
     steps:
       - name: add comment
-        uses: peter-evans/create-or-update-comment@v3
+        uses: peter-evans/create-or-update-comment@23ff15729ef2fc348714a3bb66d2f655ca9066f2 # v3
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr-id }}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR finishes the job of PR #139 and pins GitHub Actions versions to full length commit SHA.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
