### PR TITLE
docs: Add swfw property to examples heredoc

### DIFF
--- a/examples/common_vmseries/.header.md
+++ b/examples/common_vmseries/.header.md
@@ -2,6 +2,7 @@
 short_title: Common Firewall Option
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture. Common NGFW Option
 

--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -2,6 +2,7 @@
 short_title: Common Firewall Option
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture. Common NGFW Option
 

--- a/examples/common_vmseries_and_autoscale/.header.md
+++ b/examples/common_vmseries_and_autoscale/.header.md
@@ -2,6 +2,7 @@
 short_title: Common Firewall Option with Autoscaling
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Common NGFW Option with Autoscaling
 

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -2,6 +2,7 @@
 short_title: Common Firewall Option with Autoscaling
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Common NGFW Option with Autoscaling
 

--- a/examples/dedicated_vmseries/.header.md
+++ b/examples/dedicated_vmseries/.header.md
@@ -2,6 +2,7 @@
 short_title: Dedicated Firewall Option
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option
 

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -2,6 +2,7 @@
 short_title: Dedicated Firewall Option
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option
 

--- a/examples/dedicated_vmseries_and_autoscale/.header.md
+++ b/examples/dedicated_vmseries_and_autoscale/.header.md
@@ -2,6 +2,7 @@
 short_title: Dedicated Firewall Option with Autoscaling
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option with Autoscaling
 

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -2,6 +2,7 @@
 short_title: Dedicated Firewall Option with Autoscaling
 type: refarch
 show_in_hub: true
+swfw: vmseries
 ---
 # Reference Architecture with Terraform: VM-Series in Azure, Centralized Architecture, Dedicated Inbound NGFW Option with Autoscaling
 

--- a/examples/gwlb_with_vmseries/.header.md
+++ b/examples/gwlb_with_vmseries/.header.md
@@ -2,6 +2,7 @@
 short_title: GWLB Firewall Option
 type: example
 show_in_hub: false
+swfw: vmseries
 ---
 # VM-Series Azure Gateway Load Balancer example
 

--- a/examples/gwlb_with_vmseries/README.md
+++ b/examples/gwlb_with_vmseries/README.md
@@ -2,6 +2,7 @@
 short_title: GWLB Firewall Option
 type: example
 show_in_hub: false
+swfw: vmseries
 ---
 # VM-Series Azure Gateway Load Balancer example
 

--- a/examples/standalone_vmseries/.header.md
+++ b/examples/standalone_vmseries/.header.md
@@ -2,6 +2,7 @@
 short_title: Standalone VM-Series Deployment
 type: example
 show_in_hub: false
+swfw: vmseries
 ---
 # Palo Alto Networks Next Generation deployment example
 

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -2,6 +2,7 @@
 short_title: Standalone VM-Series Deployment
 type: example
 show_in_hub: false
+swfw: vmseries
 ---
 # Palo Alto Networks Next Generation deployment example
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds `swfw` property to heredoc of each example README (except for `standalone_panorama` ???). The value can be either `cloudngfw` or `vmseries`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#28 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
