### PR TITLE
feat: Switch LB & AppGW health probes to use http/https

### DIFF
--- a/examples/common_vmseries/README.md
+++ b/examples/common_vmseries/README.md
@@ -770,7 +770,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/common_vmseries/example.tfvars
+++ b/examples/common_vmseries/example.tfvars
@@ -148,6 +148,13 @@ load_balancers = {
       nsg_key      = "public"
       source_ips   = ["1.1.1.1/32"] # TODO: Whitelist public IP addresses that will be used to access LB
     }
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "app1" = {
         name             = "app1"
@@ -155,9 +162,10 @@ load_balancers = {
         create_public_ip = true
         in_rules = {
           "balanceHttp" = {
-            name     = "HTTP"
-            protocol = "Tcp"
-            port     = 80
+            name             = "HTTP"
+            protocol         = "Tcp"
+            port             = 80
+            health_probe_key = "https"
           }
         }
       }
@@ -166,6 +174,13 @@ load_balancers = {
   "private" = {
     name     = "private-lb"
     vnet_key = "transit"
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "ha-ports" = {
         name               = "private-vmseries"
@@ -173,9 +188,10 @@ load_balancers = {
         private_ip_address = "10.0.0.46"
         in_rules = {
           HA_PORTS = {
-            name     = "HA-ports"
-            port     = 0
-            protocol = "All"
+            name             = "HA-ports"
+            port             = 0
+            protocol         = "All"
+            health_probe_key = "https"
           }
         }
       }
@@ -199,9 +215,18 @@ appgws = {
     }
     backend_settings = {
       http = {
-        name     = "http"
-        port     = 80
+        name      = "http"
+        port      = 80
+        protocol  = "Http"
+        probe_key = "http"
+      }
+    }
+    probes = {
+      http = {
+        name     = "http-probe"
         protocol = "Http"
+        host     = "127.0.0.1"
+        path     = "/unauth/php/health.php"
       }
     }
     rewrites = {

--- a/examples/common_vmseries/templates/bootstrap_common.tmpl
+++ b/examples/common_vmseries/templates/bootstrap_common.tmpl
@@ -139,6 +139,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries/templates/bootstrap_inbound.tmpl
+++ b/examples/common_vmseries/templates/bootstrap_inbound.tmpl
@@ -138,6 +138,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries/templates/bootstrap_obew.tmpl
+++ b/examples/common_vmseries/templates/bootstrap_obew.tmpl
@@ -135,6 +135,7 @@
                 <entry name="168.63.129.16"/>
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries/variables.tf
+++ b/examples/common_vmseries/variables.tf
@@ -456,7 +456,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/common_vmseries_and_autoscale/README.md
+++ b/examples/common_vmseries_and_autoscale/README.md
@@ -797,7 +797,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/common_vmseries_and_autoscale/example.tfvars
+++ b/examples/common_vmseries_and_autoscale/example.tfvars
@@ -148,6 +148,13 @@ load_balancers = {
       nsg_key      = "public"
       source_ips   = ["1.1.1.1/32"] # TODO: Whitelist public IP addresses that will be used to access LB
     }
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "app1" = {
         name             = "app1"
@@ -155,9 +162,10 @@ load_balancers = {
         create_public_ip = true
         in_rules = {
           "balanceHttp" = {
-            name     = "HTTP"
-            protocol = "Tcp"
-            port     = 80
+            name             = "HTTP"
+            protocol         = "Tcp"
+            port             = 80
+            health_probe_key = "https"
           }
         }
       }
@@ -166,6 +174,13 @@ load_balancers = {
   "private" = {
     name     = "private-lb"
     vnet_key = "transit"
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "ha-ports" = {
         name               = "private-vmseries"
@@ -173,9 +188,10 @@ load_balancers = {
         private_ip_address = "10.0.0.46"
         in_rules = {
           HA_PORTS = {
-            name     = "HA-ports"
-            port     = 0
-            protocol = "All"
+            name             = "HA-ports"
+            port             = 0
+            protocol         = "All"
+            health_probe_key = "https"
           }
         }
       }
@@ -199,9 +215,18 @@ appgws = {
     }
     backend_settings = {
       http = {
-        name     = "http"
-        port     = 80
+        name      = "http"
+        port      = 80
+        protocol  = "Http"
+        probe_key = "http"
+      }
+    }
+    probes = {
+      http = {
+        name     = "http-probe"
         protocol = "Http"
+        host     = "127.0.0.1"
+        path     = "/unauth/php/health.php"
       }
     }
     rewrites = {

--- a/examples/common_vmseries_and_autoscale/templates/bootstrap_common.tmpl
+++ b/examples/common_vmseries_and_autoscale/templates/bootstrap_common.tmpl
@@ -139,6 +139,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries_and_autoscale/templates/bootstrap_inbound.tmpl
+++ b/examples/common_vmseries_and_autoscale/templates/bootstrap_inbound.tmpl
@@ -138,6 +138,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries_and_autoscale/templates/bootstrap_obew.tmpl
+++ b/examples/common_vmseries_and_autoscale/templates/bootstrap_obew.tmpl
@@ -135,6 +135,7 @@
                 <entry name="168.63.129.16"/>
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/common_vmseries_and_autoscale/variables.tf
+++ b/examples/common_vmseries_and_autoscale/variables.tf
@@ -456,7 +456,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/dedicated_vmseries/README.md
+++ b/examples/dedicated_vmseries/README.md
@@ -774,7 +774,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/dedicated_vmseries/example.tfvars
+++ b/examples/dedicated_vmseries/example.tfvars
@@ -134,6 +134,13 @@ load_balancers = {
       nsg_key      = "public"
       source_ips   = ["1.1.1.1/32"] # TODO: Whitelist public IP addresses that will be used to access LB
     }
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "app1" = {
         name             = "app1"
@@ -141,9 +148,10 @@ load_balancers = {
         create_public_ip = true
         in_rules = {
           "balanceHttp" = {
-            name     = "HTTP"
-            protocol = "Tcp"
-            port     = 80
+            name             = "HTTP"
+            protocol         = "Tcp"
+            port             = 80
+            health_probe_key = "https"
           }
         }
       }
@@ -152,6 +160,13 @@ load_balancers = {
   "private" = {
     name     = "private-lb"
     vnet_key = "transit"
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "ha-ports" = {
         name               = "private-vmseries"
@@ -159,9 +174,10 @@ load_balancers = {
         private_ip_address = "10.0.0.46"
         in_rules = {
           HA_PORTS = {
-            name     = "HA-ports"
-            port     = 0
-            protocol = "All"
+            name             = "HA-ports"
+            port             = 0
+            protocol         = "All"
+            health_probe_key = "https"
           }
         }
       }

--- a/examples/dedicated_vmseries/templates/bootstrap_common.tmpl
+++ b/examples/dedicated_vmseries/templates/bootstrap_common.tmpl
@@ -139,6 +139,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries/templates/bootstrap_inbound.tmpl
+++ b/examples/dedicated_vmseries/templates/bootstrap_inbound.tmpl
@@ -138,6 +138,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries/templates/bootstrap_obew.tmpl
+++ b/examples/dedicated_vmseries/templates/bootstrap_obew.tmpl
@@ -135,6 +135,7 @@
                 <entry name="168.63.129.16"/>
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries/variables.tf
+++ b/examples/dedicated_vmseries/variables.tf
@@ -456,7 +456,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/dedicated_vmseries_and_autoscale/README.md
+++ b/examples/dedicated_vmseries_and_autoscale/README.md
@@ -791,7 +791,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/dedicated_vmseries_and_autoscale/example.tfvars
+++ b/examples/dedicated_vmseries_and_autoscale/example.tfvars
@@ -148,6 +148,13 @@ load_balancers = {
       nsg_key      = "public"
       source_ips   = ["1.1.1.1/32"] # TODO: Whitelist public IP addresses that will be used to access LB
     }
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "app1" = {
         name             = "app1"
@@ -155,9 +162,10 @@ load_balancers = {
         create_public_ip = true
         in_rules = {
           "balanceHttp" = {
-            name     = "HTTP"
-            protocol = "Tcp"
-            port     = 80
+            name             = "HTTP"
+            protocol         = "Tcp"
+            port             = 80
+            health_probe_key = "https"
           }
         }
       }
@@ -167,6 +175,13 @@ load_balancers = {
     name     = "private-lb"
     zones    = null
     vnet_key = "transit"
+    health_probes = {
+      https = {
+        name         = "https-probe"
+        protocol     = "Https"
+        request_path = "/unauth/php/health.php"
+      }
+    }
     frontend_ips = {
       "ha-ports" = {
         name               = "private-vmseries"
@@ -174,9 +189,10 @@ load_balancers = {
         private_ip_address = "10.0.0.46"
         in_rules = {
           HA_PORTS = {
-            name     = "HA-ports"
-            port     = 0
-            protocol = "All"
+            name             = "HA-ports"
+            port             = 0
+            protocol         = "All"
+            health_probe_key = "https"
           }
         }
       }

--- a/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_common.tmpl
+++ b/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_common.tmpl
@@ -139,6 +139,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_inbound.tmpl
+++ b/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_inbound.tmpl
@@ -138,6 +138,7 @@
 %{ endfor ~}
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_obew.tmpl
+++ b/examples/dedicated_vmseries_and_autoscale/templates/bootstrap_obew.tmpl
@@ -135,6 +135,7 @@
                 <entry name="168.63.129.16"/>
               </permitted-ip>
               <http>yes</http>
+              <https>yes</https>
             </entry>
           </interface-management-profile>
         </profiles>

--- a/examples/dedicated_vmseries_and_autoscale/variables.tf
+++ b/examples/dedicated_vmseries_and_autoscale/variables.tf
@@ -456,7 +456,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/gwlb_with_vmseries/example.tfvars
+++ b/examples/gwlb_with_vmseries/example.tfvars
@@ -100,9 +100,9 @@ gateway_load_balancers = {
     }
 
     health_probe = {
-      name     = "custom-health-probe"
-      port     = 80
-      protocol = "Tcp"
+      name         = "https-probe"
+      protocol     = "Https"
+      request_path = "/unauth/php/health.php"
     }
 
     backends = {

--- a/examples/gwlb_with_vmseries/templates/bootstrap-gwlb.tftpl
+++ b/examples/gwlb_with_vmseries/templates/bootstrap-gwlb.tftpl
@@ -152,6 +152,7 @@
           <interface-management-profile>
             <entry name="gwlb-healthcheck">
               <http>yes</http>
+              <https>yes</https>
               <permitted-ip>
                 <entry name="168.63.129.16"/>
               </permitted-ip>

--- a/examples/standalone_vmseries/README.md
+++ b/examples/standalone_vmseries/README.md
@@ -708,7 +708,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/examples/standalone_vmseries/variables.tf
+++ b/examples/standalone_vmseries/variables.tf
@@ -456,7 +456,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/tests/appgw/README.md
+++ b/tests/appgw/README.md
@@ -269,7 +269,7 @@ map(object({
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string

--- a/tests/appgw/example.tfvars
+++ b/tests/appgw/example.tfvars
@@ -371,7 +371,7 @@ appgws = {
   #       protocol                  = "Http"
   #       timeout                   = 60
   #       use_cookie_based_affinity = true
-  #       probe                     = "http"
+  #       probe_key                 = "http"
   #     }
   #     https1 = {
   #       name                      = "https1-settings"
@@ -387,7 +387,7 @@ appgws = {
   #           path = "./files/ca-cert1.pem"
   #         }
   #       }
-  #       probe = "https1"
+  #       probe_key = "https1"
   #     }
   #     https2 = {
   #       name                      = "https2-settings"
@@ -403,7 +403,7 @@ appgws = {
   #           path = "./files/ca-cert2.pem"
   #         }
   #       }
-  #       probe = "https2"
+  #       probe_key = "https2"
   #     }
   #   }
   #   probes = {

--- a/tests/appgw/variables.tf
+++ b/tests/appgw/variables.tf
@@ -274,7 +274,7 @@ variable "appgws" {
       timeout                   = optional(number)
       use_cookie_based_affinity = optional(bool)
       affinity_cookie_name      = optional(string)
-      probe                     = optional(string)
+      probe_key                 = optional(string)
       root_certs = optional(map(object({
         name = string
         path = string


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR changes the Load Balancer & Application Gateway Health Probes to use HTTP / HTTPS instead of TCP. Dedicated health probe endpoint on the VM-Series is used.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[Load Balancer health check probes to TCP](https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA14u000000oM4KCAU&refURL=http%3A%2F%2Fknowledgebase.paloaltonetworks.com%2FKCSArticleDetail)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deploying manually.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
