### PR TITLE
fix: Add HTTP code match to AppGW health probe

### DIFF
--- a/examples/common_vmseries/example.tfvars
+++ b/examples/common_vmseries/example.tfvars
@@ -223,10 +223,11 @@ appgws = {
     }
     probes = {
       http = {
-        name     = "http-probe"
-        protocol = "Http"
-        host     = "127.0.0.1"
-        path     = "/unauth/php/health.php"
+        name       = "http-probe"
+        protocol   = "Http"
+        host       = "127.0.0.1"
+        path       = "/unauth/php/health.php"
+        match_code = [200]
       }
     }
     rewrites = {

--- a/examples/common_vmseries_and_autoscale/example.tfvars
+++ b/examples/common_vmseries_and_autoscale/example.tfvars
@@ -223,10 +223,11 @@ appgws = {
     }
     probes = {
       http = {
-        name     = "http-probe"
-        protocol = "Http"
-        host     = "127.0.0.1"
-        path     = "/unauth/php/health.php"
+        name       = "http-probe"
+        protocol   = "Http"
+        host       = "127.0.0.1"
+        path       = "/unauth/php/health.php"
+        match_code = [200]
       }
     }
     rewrites = {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This PR adds HTTP response status code match criteria to Application Gateway custom health probe.
Applies to VM-Series based examples using AppGW.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Solves idempotence issue introduced in PR #148 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally deploying.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
