### PR TITLE
ci: Replace deprecated environment variable to skip resource providers registration

### DIFF
--- a/.github/actions/terratest/action.yml
+++ b/.github/actions/terratest/action.yml
@@ -43,7 +43,7 @@ runs:
       env:
         TPATH: ${{ inputs.path }}
         ARM_USE_OIDC: true
-        ARM_SKIP_PROVIDER_REGISTRATION: true
+        ARM_RESOURCE_PROVIDER_REGISTRATIONS: none
         ACTION: ${{ inputs.terratest_action }}
         PRID: ${{ inputs.pr-id }}
       shell: bash


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR replaces deprecated `ARM_SKIP_PROVIDER_REGISTRATION` with new `ARM_RESOURCE_PROVIDER_REGISTRATIONS` environment variable in the CI files. Old property would stop working in AzureRM v5.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

> This property is deprecated and will be removed in v5.0 of the AzureRM provider. Please use the `resource_provider_registrations` property instead.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

ChatOps

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
