### PR TITLE
feat: Add easy AIRS support to vmseries and vmss modules

### DIFF
--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -667,6 +667,7 @@ However, if values are set in those maps, they still take precedence over the on
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
+
 - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
                         instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -667,7 +667,8 @@ However, if values are set in those maps, they still take precedence over the on
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
-  
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -681,8 +682,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -851,6 +853,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_gwlb/main.tf
+++ b/examples/vmseries_gwlb/main.tf
@@ -283,7 +283,8 @@ module "vmseries" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.vmseries_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.vmseries_universal.use_airs, false)
+      version  = try(each.value.image.version, var.vmseries_universal.version, null)
     }
   )
   virtual_machine = merge(

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -401,7 +401,8 @@ variable "vmseries_universal" {
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
-  
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -412,8 +413,9 @@ variable "vmseries_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -597,6 +599,7 @@ variable "vmseries" {
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -401,6 +401,7 @@ variable "vmseries_universal" {
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
+
   - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
                           instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -951,7 +951,7 @@ However, if values are set in those maps, they still take precedence over the on
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
-  
+
 - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
                         instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -952,6 +952,8 @@ universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
   
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -965,8 +967,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -1140,6 +1143,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -407,7 +407,8 @@ module "vmseries" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.vmseries_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.vmseries_universal.use_airs, false)
+      version  = try(each.value.image.version, var.vmseries_universal.version, null)
     }
   )
   virtual_machine = merge(

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -675,6 +675,8 @@ variable "vmseries_universal" {
 
   Following properties are supported:
   
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -685,8 +687,9 @@ variable "vmseries_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -876,6 +879,7 @@ variable "vmseries" {
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -674,7 +674,7 @@ variable "vmseries_universal" {
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
-  
+
   - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
                           instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -1013,7 +1013,9 @@ However, if values are set in those maps, they still take precedence over the on
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
-  
+
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1027,8 +1029,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -1202,6 +1205,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -407,7 +407,8 @@ module "vmseries" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.vmseries_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.vmseries_universal.use_airs, false)
+      version  = try(each.value.image.version, var.vmseries_universal.version, null)
     }
   )
   virtual_machine = merge(

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -674,7 +674,9 @@ variable "vmseries_universal" {
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
-  
+
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -685,8 +687,9 @@ variable "vmseries_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -876,6 +879,7 @@ variable "vmseries" {
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -1010,7 +1010,9 @@ It duplicates popular properties from `scale_sets` variable, specifically `scale
 set within this variable. As a result, all universal properties can be overriden on a per-VMSS basis.
 
 Following properties are supported:
-  
+
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1024,8 +1026,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -1214,6 +1217,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     })
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/main.tf
@@ -384,7 +384,8 @@ module "vmss" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.scale_sets_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.scale_sets_universal.use_airs, false)
+      version  = try(each.value.image.version, var.scale_sets_universal.version, null)
     }
   )
   virtual_machine_scale_set = merge(

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -651,7 +651,9 @@ variable "scale_sets_universal" {
   set within this variable. As a result, all universal properties can be overriden on a per-VMSS basis.
 
   Following properties are supported:
-  
+
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -662,8 +664,9 @@ variable "scale_sets_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -845,6 +848,7 @@ variable "scale_sets" {
       ssh_keys                        = optional(list(string), [])
     })
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -1017,7 +1017,9 @@ However, if values are set in those maps, they still take precedence over the on
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
-  
+
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1031,8 +1033,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -1206,6 +1209,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -407,7 +407,8 @@ module "vmseries" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.vmseries_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.vmseries_universal.use_airs, false)
+      version  = try(each.value.image.version, var.vmseries_universal.version, null)
     }
   )
   virtual_machine = merge(

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -674,7 +674,9 @@ variable "vmseries_universal" {
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
-  
+
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -685,8 +687,9 @@ variable "vmseries_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -876,6 +879,7 @@ variable "vmseries" {
       ssh_keys                        = optional(list(string), [])
     }), {})
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -1004,7 +1004,9 @@ It duplicates popular properties from `scale_sets` variable, specifically `scale
 set within this variable. As a result, all universal properties can be overriden on a per-VMSS basis.
 
 Following properties are supported:
-  
+
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1018,8 +1020,9 @@ Type:
 
 ```hcl
 object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -1208,6 +1211,7 @@ map(object({
       ssh_keys                        = optional(list(string), [])
     })
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
@@ -384,7 +384,8 @@ module "vmss" {
   image = merge(
     each.value.image,
     {
-      version = try(each.value.image.version, var.scale_sets_universal.version, null)
+      use_airs = try(each.value.image.use_airs, var.scale_sets_universal.use_airs, false)
+      version  = try(each.value.image.version, var.scale_sets_universal.version, null)
     }
   )
   virtual_machine_scale_set = merge(

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -651,7 +651,9 @@ variable "scale_sets_universal" {
   set within this variable. As a result, all universal properties can be overriden on a per-VMSS basis.
 
   Following properties are supported:
-  
+
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -662,8 +664,9 @@ variable "scale_sets_universal" {
   EOF
   default     = {}
   type = object({
-    version = optional(string)
-    size    = optional(string)
+    use_airs = optional(bool)
+    version  = optional(string)
+    size     = optional(string)
     bootstrap_options = optional(object({
       type                                  = optional(string)
       ip-address                            = optional(string)
@@ -845,6 +848,7 @@ variable "scale_sets" {
       ssh_keys                        = optional(list(string), [])
     })
     image = optional(object({
+      use_airs                = optional(bool)
       version                 = optional(string)
       publisher               = optional(string)
       offer                   = optional(string)

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -147,6 +147,8 @@ Basic Azure VM image configuration.
 
 Following properties are available:
 
+- `use_airs`                - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is
+                              used instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`                 - (`string`, optional, defaults to `null`) VM-Series PAN-OS version; list available with
                               `az vm image list -o table --publisher paloaltonetworks --offer vmseries-flex --all`.
 - `publisher`               - (`string`, optional, defaults to `paloaltonetworks`) the Azure Publisher identifier for a image
@@ -168,6 +170,7 @@ Type:
 
 ```hcl
 object({
+    use_airs                = optional(bool, false)
     version                 = optional(string)
     publisher               = optional(string, "paloaltonetworks")
     offer                   = optional(string, "vmseries-flex")

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -87,9 +87,9 @@ resource "azurerm_linux_virtual_machine" "this" {
   dynamic "source_image_reference" {
     for_each = var.image.custom_id == null ? [1] : []
     content {
-      publisher = var.image.publisher
-      offer     = var.image.offer
-      sku       = var.image.sku
+      publisher = var.image.use_airs ? "paloaltonetworks" : var.image.publisher
+      offer     = var.image.use_airs ? "airs-flex" : var.image.offer
+      sku       = var.image.use_airs ? "airs-byol" : var.image.sku
       version   = var.image.version
     }
   }
@@ -98,9 +98,9 @@ resource "azurerm_linux_virtual_machine" "this" {
     for_each = var.image.enable_marketplace_plan ? [1] : []
 
     content {
-      name      = var.image.sku
-      publisher = var.image.publisher
-      product   = var.image.offer
+      name      = var.image.use_airs ? "airs-byol" : var.image.sku
+      publisher = var.image.use_airs ? "paloaltonetworks" : var.image.publisher
+      product   = var.image.use_airs ? "airs-flex" : var.image.offer
     }
   }
 

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -52,6 +52,8 @@ variable "image" {
 
   Following properties are available:
 
+  - `use_airs`                - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is
+                                used instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`                 - (`string`, optional, defaults to `null`) VM-Series PAN-OS version; list available with
                                 `az vm image list -o table --publisher paloaltonetworks --offer vmseries-flex --all`.
   - `publisher`               - (`string`, optional, defaults to `paloaltonetworks`) the Azure Publisher identifier for a image
@@ -69,6 +71,7 @@ variable "image" {
   `custom_id` and `version` properties are mutually exclusive.
   EOF
   type = object({
+    use_airs                = optional(bool, false)
     version                 = optional(string)
     publisher               = optional(string, "paloaltonetworks")
     offer                   = optional(string, "vmseries-flex")

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -218,6 +218,8 @@ Basic Azure VM configuration.
 
 Following properties are available:
 
+- `use_airs`                - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is
+                              used instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`                 - (`string`, optional, defaults to `null`) VM-Series PAN-OS version; list available with 
                               `az vm image list -o table --publisher paloaltonetworks --offer vmseries-flex --all`.
 - `publisher`               - (`string`, optional, defaults to `paloaltonetworks`) the Azure Publisher identifier for an image
@@ -239,6 +241,7 @@ Type:
 
 ```hcl
 object({
+    use_airs                = optional(bool, false)
     version                 = optional(string)
     publisher               = optional(string, "paloaltonetworks")
     offer                   = optional(string, "vmseries-flex")

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -17,6 +17,17 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
   location             = var.region
   resource_group_name  = var.resource_group_name
 
+  encryption_at_host_enabled    = var.virtual_machine_scale_set.encryption_at_host_enabled
+  overprovision                 = var.virtual_machine_scale_set.overprovision
+  extension_operations_enabled  = var.virtual_machine_scale_set.allow_extension_operations
+  platform_fault_domain_count   = var.virtual_machine_scale_set.platform_fault_domain_count
+  single_placement_group        = var.virtual_machine_scale_set.single_placement_group
+  capacity_reservation_group_id = var.virtual_machine_scale_set.capacity_reservation_group_id
+  sku                           = var.virtual_machine_scale_set.size
+  zones                         = var.virtual_machine_scale_set.zones
+  zone_balance                  = length(coalesce(var.virtual_machine_scale_set.zones, [])) >= 2 # zone balance is available from at least 2 zones
+  provision_vm_agent            = false
+
   admin_username                  = var.authentication.username
   admin_password                  = var.authentication.disable_password_authentication ? null : local.password
   disable_password_authentication = var.authentication.disable_password_authentication
@@ -29,40 +40,29 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     }
   }
 
-  encryption_at_host_enabled    = var.virtual_machine_scale_set.encryption_at_host_enabled
-  overprovision                 = var.virtual_machine_scale_set.overprovision
-  extension_operations_enabled  = var.virtual_machine_scale_set.allow_extension_operations
-  platform_fault_domain_count   = var.virtual_machine_scale_set.platform_fault_domain_count
-  single_placement_group        = var.virtual_machine_scale_set.single_placement_group
-  capacity_reservation_group_id = var.virtual_machine_scale_set.capacity_reservation_group_id
-  sku                           = var.virtual_machine_scale_set.size
-  zones                         = var.virtual_machine_scale_set.zones
-  zone_balance                  = length(coalesce(var.virtual_machine_scale_set.zones, [])) >= 2 # zone balance is available from at least 2 zones
-  provision_vm_agent            = false
-
-  dynamic "plan" {
-    for_each = var.image.enable_marketplace_plan ? [1] : []
-    content {
-      name      = var.image.sku
-      publisher = var.image.publisher
-      product   = var.image.offer
-    }
-  }
-
-  source_image_reference {
-    publisher = var.image.custom_id == null ? var.image.publisher : null
-    offer     = var.image.custom_id == null ? var.image.offer : null
-    sku       = var.image.custom_id == null ? var.image.sku : null
-    version   = var.image.version
-  }
-
-  source_image_id = var.image.custom_id
   os_disk {
     caching                = "ReadWrite"
     disk_encryption_set_id = var.virtual_machine_scale_set.disk_encryption_set_id # the Disk Encryption Set must have the Reader Role Assignment scoped on the Key Vault, in addition to an Access Policy to the Key Vault
     storage_account_type   = var.virtual_machine_scale_set.disk_type
   }
 
+  source_image_id = var.image.custom_id
+
+  source_image_reference {
+    publisher = var.image.use_airs ? "paloaltonetworks" : var.image.publisher
+    offer     = var.image.use_airs ? "airs-flex" : var.image.offer
+    sku       = var.image.use_airs ? "airs-byol" : var.image.sku
+    version   = var.image.version
+  }
+
+  dynamic "plan" {
+    for_each = var.image.enable_marketplace_plan ? [1] : []
+    content {
+      name      = var.image.use_airs ? "airs-byol" : var.image.sku
+      publisher = var.image.use_airs ? "paloaltonetworks" : var.image.publisher
+      product   = var.image.use_airs ? "airs-flex" : var.image.offer
+    }
+  }
 
   instances = var.autoscaling_configuration.default_count
 

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -69,6 +69,8 @@ variable "image" {
 
   Following properties are available:
 
+  - `use_airs`                - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is
+                                used instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`                 - (`string`, optional, defaults to `null`) VM-Series PAN-OS version; list available with 
                                 `az vm image list -o table --publisher paloaltonetworks --offer vmseries-flex --all`.
   - `publisher`               - (`string`, optional, defaults to `paloaltonetworks`) the Azure Publisher identifier for an image
@@ -86,6 +88,7 @@ variable "image" {
   `custom_id` and `version` properties are mutually exclusive.
   EOF
   type = object({
+    use_airs                = optional(bool, false)
     version                 = optional(string)
     publisher               = optional(string, "paloaltonetworks")
     offer                   = optional(string, "vmseries-flex")


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Add support for AI Runtime Security image with a single switch (boolean value) passed to either `vmseries` or `vmss` modules. The flag is called `use_airs` and is `false` by default.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#160 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
