### PR TITLE
feat: Add PIP Prefix ID as an option to source a PIP Prefix

### DIFF
--- a/examples/cloudngfw_centralized_single_vwan/README.md
+++ b/examples/cloudngfw_centralized_single_vwan/README.md
@@ -468,6 +468,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/cloudngfw_centralized_single_vwan/variables.tf
+++ b/examples/cloudngfw_centralized_single_vwan/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/cloudngfw_centralized_vnet/README.md
+++ b/examples/cloudngfw_centralized_vnet/README.md
@@ -468,6 +468,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/cloudngfw_centralized_vnet/variables.tf
+++ b/examples/cloudngfw_centralized_vnet/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/cloudngfw_distributed/README.md
+++ b/examples/cloudngfw_distributed/README.md
@@ -459,6 +459,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/cloudngfw_distributed/variables.tf
+++ b/examples/cloudngfw_distributed/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/panorama_standalone/README.md
+++ b/examples/panorama_standalone/README.md
@@ -365,6 +365,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/panorama_standalone/variables.tf
+++ b/examples/panorama_standalone/variables.tf
@@ -160,6 +160,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -414,6 +414,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -411,6 +411,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -473,6 +473,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -500,6 +500,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool
@@ -1297,6 +1298,7 @@ map(object({
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
       load_balancer_key              = optional(string)
       application_gateway_key        = optional(string)
     }))

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool
@@ -928,6 +929,7 @@ variable "scale_sets" {
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
       load_balancer_key              = optional(string)
       application_gateway_key        = optional(string)
     }))

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -477,6 +477,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -494,6 +494,7 @@ object({
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool
@@ -1291,6 +1292,7 @@ map(object({
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
       load_balancer_key              = optional(string)
       application_gateway_key        = optional(string)
     }))

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -179,6 +179,7 @@ variable "public_ips" {
       idle_timeout_in_minutes    = optional(number)
       prefix_name                = optional(string)
       prefix_resource_group_name = optional(string)
+      prefix_id                  = optional(string)
     })), {})
     public_ip_prefixes = optional(map(object({
       create              = bool
@@ -928,6 +929,7 @@ variable "scale_sets" {
       pip_idle_timeout_in_minutes    = optional(number)
       pip_prefix_name                = optional(string)
       pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
       load_balancer_key              = optional(string)
       application_gateway_key        = optional(string)
     }))

--- a/modules/public_ip/README.md
+++ b/modules/public_ip/README.md
@@ -207,6 +207,8 @@ List of available properties:
                                  should be allocated.
 - `prefix_resource_group_name` - (`string`, optional, defaults to the PIP's RG) name of a Resource Group hosting an existing
                                  Public IP Prefix resource.
+- `prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the properties
+                                 above (name and resource group), in case you want to avoid using a data source block.
   
 Example:
 
@@ -252,6 +254,7 @@ map(object({
     idle_timeout_in_minutes    = optional(number)
     prefix_name                = optional(string)
     prefix_resource_group_name = optional(string)
+    prefix_id                  = optional(string)
   }))
 ```
 

--- a/modules/public_ip/main.tf
+++ b/modules/public_ip/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_public_ip" "this" {
   zones                   = each.value.zones
   domain_name_label       = each.value.domain_name_label
   idle_timeout_in_minutes = each.value.idle_timeout_in_minutes
-  public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[each.key].id, null)
+  public_ip_prefix_id     = try(each.value.prefix_id, data.azurerm_public_ip_prefix.allocate[each.key].id, null)
   tags                    = var.tags
 }
 

--- a/modules/public_ip/variables.tf
+++ b/modules/public_ip/variables.tf
@@ -30,6 +30,8 @@ variable "public_ip_addresses" {
                                    should be allocated.
   - `prefix_resource_group_name` - (`string`, optional, defaults to the PIP's RG) name of a Resource Group hosting an existing
                                    Public IP Prefix resource.
+  - `prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the properties
+                                   above (name and resource group), in case you want to avoid using a data source block.
   
   Example:
 
@@ -72,6 +74,7 @@ variable "public_ip_addresses" {
     idle_timeout_in_minutes    = optional(number)
     prefix_name                = optional(string)
     prefix_resource_group_name = optional(string)
+    prefix_id                  = optional(string)
   }))
   validation { # idle_timeout_in_minutes
     condition = alltrue([

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -279,6 +279,9 @@ Following configuration options are available:
                                      Addresses should be allocated.
 - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
                                      existing Public IP Prefix resource.
+- `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
+                                     properties above (name and resource group), in case you want to avoid using a data source
+                                     block.
 - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
                                      backend pools to associate the interface with.
 - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
@@ -317,6 +320,7 @@ list(object({
     pip_idle_timeout_in_minutes    = optional(number)
     pip_prefix_name                = optional(string)
     pip_prefix_resource_group_name = optional(string)
+    pip_prefix_id                  = optional(string)
     lb_backend_pool_ids            = optional(list(string), [])
     appgw_backend_pool_ids         = optional(list(string), [])
   }))

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -102,7 +102,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
             name                    = nic.value.name
             domain_name_label       = nic.value.pip_domain_name_label
             idle_timeout_in_minutes = nic.value.pip_idle_timeout_in_minutes
-            public_ip_prefix_id     = try(data.azurerm_public_ip_prefix.allocate[nic.value.name].id, null)
+            public_ip_prefix_id = try(
+              nic.value.pip_prefix_id, data.azurerm_public_ip_prefix.allocate[nic.value.name].id, null
+            )
           }
         }
       }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -238,6 +238,9 @@ variable "interfaces" {
                                        Addresses should be allocated.
   - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
                                        existing Public IP Prefix resource.
+  - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
+                                       properties above (name and resource group), in case you want to avoid using a data source
+                                       block.
   - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
                                        backend pools to associate the interface with.
   - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
@@ -272,6 +275,7 @@ variable "interfaces" {
     pip_idle_timeout_in_minutes    = optional(number)
     pip_prefix_name                = optional(string)
     pip_prefix_resource_group_name = optional(string)
+    pip_prefix_id                  = optional(string)
     lb_backend_pool_ids            = optional(list(string), [])
     appgw_backend_pool_ids         = optional(list(string), [])
   }))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds support for sourcing a Public IP Prefix resource by specifying its ID instead of name and resource group name, when creating a new Public IP resource using `public_ip` or `vmss` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#157 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
