### PR TITLE
fix: Add ARE tag to XML bootstrap templates

### DIFF
--- a/examples/vmseries_gwlb/templates/bootstrap-gwlb.tftpl
+++ b/examples/vmseries_gwlb/templates/bootstrap-gwlb.tftpl
@@ -484,6 +484,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common/templates/bootstrap_common.tmpl
+++ b/examples/vmseries_transit_vnet_common/templates/bootstrap_common.tmpl
@@ -629,6 +629,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common/templates/bootstrap_inbound.tmpl
+++ b/examples/vmseries_transit_vnet_common/templates/bootstrap_inbound.tmpl
@@ -488,6 +488,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common/templates/bootstrap_obew.tmpl
+++ b/examples/vmseries_transit_vnet_common/templates/bootstrap_obew.tmpl
@@ -485,6 +485,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_common.tmpl
+++ b/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_common.tmpl
@@ -629,6 +629,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_inbound.tmpl
+++ b/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_inbound.tmpl
@@ -488,6 +488,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_obew.tmpl
+++ b/examples/vmseries_transit_vnet_common_autoscale/templates/bootstrap_obew.tmpl
@@ -485,6 +485,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_common.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_common.tmpl
@@ -629,6 +629,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_inbound.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_inbound.tmpl
@@ -488,6 +488,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_obew.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated/templates/bootstrap_obew.tmpl
@@ -485,6 +485,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_common.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_common.tmpl
@@ -629,6 +629,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_inbound.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_inbound.tmpl
@@ -488,6 +488,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_obew.tmpl
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/templates/bootstrap_obew.tmpl
@@ -485,6 +485,7 @@
               </type>
             </initcfg>
           </management>
+          <advance-routing>yes</advance-routing>
         </setting>
 %{ if ai_instr_key != null ~}
         <plugins>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR adds `<advance-routing>yes</advance-routing>` tag to XML bootstrap templates.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Knowledge Article 000028560 (for some PAN-OS versions, this tag is required in addition to bootstrap parameter in init-cfg for Advanced Routing Engine to function properly).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
