### PR TITLE
feat(vmseries_secondary_ips): Add VMSeries interface secondary IPs

### DIFF
--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -831,7 +831,15 @@ The most basic properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-  - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                        the IP to change.
+    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -919,19 +927,22 @@ map(object({
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      gwlb_key                      = optional(string)
-      gwlb_backend_key              = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      gwlb_key                = optional(string)
+      gwlb_backend_key        = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
 ```

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -833,13 +833,13 @@ The most basic properties are as follows:
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                   skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                   to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                   the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -931,9 +931,9 @@ map(object({
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -324,7 +324,7 @@ Example:
 ```
 name_prefix = "test-"
 ```
-  
+
 **Note!** \
 This prefix is not applied to existing resources. If you plan to reuse i.e. a VNET please specify it's full name,
 even if it is also prefixed with the same value as the one in this property.
@@ -340,7 +340,7 @@ Default value: ``
 
 When set to `true` it will cause a Resource Group creation.
 Name of the newly specified RG is controlled by `resource_group_name`.
-  
+
 When set to `false` the `resource_group_name` parameter is used to specify a name of an existing Resource Group.
 
 
@@ -440,14 +440,14 @@ Following settings are available:
 - `vnet_key`      - (`string`, required) a name (key value) of a VNET defined in `var.vnets` that hosts a subnet this GWLB will
                     be assigned to.
 - `subnet_key`    - (`string`, required) a name (key value) of Subnet the GWLB will be assigned to, defined in `var.vnets` for
-                    a VNET described by `vnet_name`.        
+                    a VNET described by `vnet_name`.
 - `frontend_ip`   - (`object`, required) frontend IP configuration, refer to
                     [module's documentation](../../modules/gwlb/README.md) for details.
 - `health_probe`  - (`object`, optional) health probe settings, refer to
                     [module's documentation](../../modules/gwlb/README.md) for details.
 - `backends`      - (`map`, optional) map of backends, refer to
                     [module's documentation](../../modules/gwlb/README.md) for details.
-- `lb_rule`       - (`object`, optional) load balancer rule, refer to 
+- `lb_rule`       - (`object`, optional) load balancer rule, refer to
                     [module's documentation](../../modules/gwlb/README.md) for details.
 
 
@@ -502,7 +502,7 @@ Following properties are supported:
 - `name`                - (`string`, required) name of the Application Insights.
 - `update_domain_count` - (`number`, optional, defaults to Azure default) specifies the number of update domains that are used.
 - `fault_domain_count`  - (`number`, optional, defaults to Azure default) specifies the number of fault domains that are used.
-  
+
 **Note!** \
 Please keep in mind that Azure defaults are not working for every region (especially the small ones, without any Availability
 Zones). Please verify how many update and fault domain are supported in a region before deploying this resource.
@@ -583,7 +583,7 @@ You can create or re-use an existing Storage Account and/or File Share. For deta
                                 will host (created) a Storage Account. When skipped the code will fall back to
                                 `var.resource_group_name`.
 - `storage_account`           - (`map`, optional, defaults to `{}`) a map controlling basic Storage Account configuration.
-                                  
+
   The property you should pay attention to is:
 
   - `create` - (`bool`, optional, defaults to module default) controls if the Storage Account specified in the `name` property
@@ -592,8 +592,8 @@ You can create or re-use an existing Storage Account and/or File Share. For deta
   For detailed documentation see [module's documentation](../../modules/bootstrap/README.md#storage_account).
 
 - `storage_network_security`  - (`map`, optional, defaults to `{}`) a map defining network security settings for a **new**
-                                storage account. 
-                                  
+                                storage account.
+
   The properties you should pay attention to are:
 
   - `allowed_subnet_keys` - (`list`, optional, defaults to `[]`) a list of keys pointing to Subnet definitions in the
@@ -603,9 +603,9 @@ You can create or re-use an existing Storage Account and/or File Share. For deta
                             Subnets described in `allowed_subnet_keys`.
 
   For detailed documentation see [module's documentation](../../modules/bootstrap/README.md#storage_network_security).
-                            
+
 - `file_shares_configuration` - (`map`, optional, defaults to `{}`) a map defining common File Share setting.
-                                  
+
   The properties you should pay attention to are:
 
   - `create_file_shares`            - (`bool`, optional, defaults to module default) controls if the File Shares defined in the
@@ -663,15 +663,15 @@ Default value: `map[]`
 
 #### vmseries_universal
 
-A map defining common settings for all created VM-Series instances. 
-  
+A map defining common settings for all created VM-Series instances.
+
 It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
 However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
 
-- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
                         instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
@@ -752,13 +752,13 @@ The most basic properties are as follows:
 
   **Note!** \
   The `disable_password_authentication` property is by default `false` in this example. When using this value, you don't have
-  to specify anything but you can still additionally pass SSH keys for authentication. You can however set this property to 
+  to specify anything but you can still additionally pass SSH keys for authentication. You can however set this property to
   `true`, then you have to specify `ssh_keys` property.
 
   For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
 - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                       properties (mutually exclusive) that have to be set, either:
 
   - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -766,7 +766,7 @@ The most basic properties are as follows:
 
   For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#image).
 
-- `virtual_machine` - (`map`, optional, defaults to module default) a map that groups most common VM configuration options. 
+- `virtual_machine` - (`map`, optional, defaults to module default) a map that groups most common VM configuration options.
                       Most common properties are:
 
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
@@ -811,7 +811,7 @@ The most basic properties are as follows:
       **Note!** \
       Day0 configuration is **not meant** to be **secure**. It's here merely to help with the basic firewall setup. When
       `bootstrap_xml_template` is set, one of the following properties might be required.
-        
+
     - `data_snet_key`          - (`string`, required only when `bootstrap_xml_template` is set, defaults to `null`) a key
                                  pointing to a data Subnet definition in `var.vnets` (the `vnet_key` property is used to
                                  identify a VNET). The Subnet definition is used to calculate static routes for a data
@@ -822,7 +822,7 @@ The most basic properties are as follows:
     - `intranet_cidr`          - (`string`, optional, defaults to `null`) a CIDR of the Intranet - combined CIDR of all
                                  private networks. When set it will override the private Subnet CIDR for inbound traffic
                                  static routes.
-      
+
     For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#virtual_machine).
 
 - `interfaces`      - (`list`, required) configuration of all network interfaces. Order of the interfaces does matter - the
@@ -834,12 +834,12 @@ The most basic properties are as follows:
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                        the IP to change.
+                                  skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                  to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                  the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
     - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -979,12 +979,12 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
   - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#subnets).
-  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the local VNet peering.
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering.  
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the remote VNet peering.
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_gwlb/example.tfvars
+++ b/examples/vmseries_gwlb/example.tfvars
@@ -197,13 +197,26 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm01-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm01-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name             = "vm01-data"
-        subnet_key       = "data"
+        name       = "vm01-data"
+        subnet_key = "data"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         gwlb_key         = "gwlb"
         gwlb_backend_key = "backend"
       }
@@ -217,13 +230,26 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm02-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm02-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name             = "vm02-data"
-        subnet_key       = "data"
+        name       = "vm02-data"
+        subnet_key = "data"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         gwlb_key         = "gwlb"
         gwlb_backend_key = "backend"
       }

--- a/examples/vmseries_gwlb/example.tfvars
+++ b/examples/vmseries_gwlb/example.tfvars
@@ -202,8 +202,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -213,8 +213,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         gwlb_key         = "gwlb"
@@ -235,8 +235,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -246,8 +246,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         gwlb_key         = "gwlb"

--- a/examples/vmseries_gwlb/main.tf
+++ b/examples/vmseries_gwlb/main.tf
@@ -324,16 +324,16 @@ module "vmseries" {
   interfaces = [for v in each.value.interfaces : {
     name      = "${var.name_prefix}${v.name}"
     subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
-      name             = ip_config_value.name
-      create_public_ip = ip_config_value.create_public_ip
-      public_ip_name = ip_config_value.create_public_ip ? "${
-        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
-      }" : ip_config_value.public_ip_name
-      primary                       = ip_config_value.primary
-      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
-      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
-      private_ip_address            = ip_config_value.private_ip_address
+    ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+      name             = vv.name
+      create_public_ip = vv.create_public_ip
+      public_ip_name = vv.create_public_ip ? "${
+        var.name_prefix}${coalesce(vv.public_ip_name, "${v.name}-${vv.name}-pip")
+      }" : vv.public_ip_name
+      primary                       = vv.primary
+      public_ip_resource_group_name = vv.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[vv.public_ip_key], null)
+      private_ip_address            = vv.private_ip_address
       }
     }
     attach_to_lb_backend_pool    = v.load_balancer_key != null || v.gwlb_key != null

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -579,7 +579,15 @@ variable "vmseries" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-    - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                          the IP to change.
+      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -665,19 +673,22 @@ variable "vmseries" {
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      gwlb_key                      = optional(string)
-      gwlb_backend_key              = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      gwlb_key                = optional(string)
+      gwlb_backend_key        = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -21,7 +21,7 @@ variable "name_prefix" {
   ```
   name_prefix = "test-"
   ```
-  
+
   **Note!** \
   This prefix is not applied to existing resources. If you plan to reuse i.e. a VNET please specify it's full name,
   even if it is also prefixed with the same value as the one in this property.
@@ -34,7 +34,7 @@ variable "create_resource_group" {
   description = <<-EOF
   When set to `true` it will cause a Resource Group creation.
   Name of the newly specified RG is controlled by `resource_group_name`.
-  
+
   When set to `false` the `resource_group_name` parameter is used to specify a name of an existing Resource Group.
   EOF
   default     = true
@@ -202,14 +202,14 @@ variable "gateway_load_balancers" {
   - `vnet_key`      - (`string`, required) a name (key value) of a VNET defined in `var.vnets` that hosts a subnet this GWLB will
                       be assigned to.
   - `subnet_key`    - (`string`, required) a name (key value) of Subnet the GWLB will be assigned to, defined in `var.vnets` for
-                      a VNET described by `vnet_name`.        
+                      a VNET described by `vnet_name`.
   - `frontend_ip`   - (`object`, required) frontend IP configuration, refer to
                       [module's documentation](../../modules/gwlb/README.md) for details.
   - `health_probe`  - (`object`, optional) health probe settings, refer to
                       [module's documentation](../../modules/gwlb/README.md) for details.
   - `backends`      - (`map`, optional) map of backends, refer to
                       [module's documentation](../../modules/gwlb/README.md) for details.
-  - `lb_rule`       - (`object`, optional) load balancer rule, refer to 
+  - `lb_rule`       - (`object`, optional) load balancer rule, refer to
                       [module's documentation](../../modules/gwlb/README.md) for details.
   EOF
   default     = {}
@@ -258,7 +258,7 @@ variable "availability_sets" {
   - `name`                - (`string`, required) name of the Application Insights.
   - `update_domain_count` - (`number`, optional, defaults to Azure default) specifies the number of update domains that are used.
   - `fault_domain_count`  - (`number`, optional, defaults to Azure default) specifies the number of fault domains that are used.
-  
+
   **Note!** \
   Please keep in mind that Azure defaults are not working for every region (especially the small ones, without any Availability
   Zones). Please verify how many update and fault domain are supported in a region before deploying this resource.
@@ -324,7 +324,7 @@ variable "bootstrap_storages" {
                                   will host (created) a Storage Account. When skipped the code will fall back to
                                   `var.resource_group_name`.
   - `storage_account`           - (`map`, optional, defaults to `{}`) a map controlling basic Storage Account configuration.
-                                  
+
     The property you should pay attention to is:
 
     - `create` - (`bool`, optional, defaults to module default) controls if the Storage Account specified in the `name` property
@@ -333,8 +333,8 @@ variable "bootstrap_storages" {
     For detailed documentation see [module's documentation](../../modules/bootstrap/README.md#storage_account).
 
   - `storage_network_security`  - (`map`, optional, defaults to `{}`) a map defining network security settings for a **new**
-                                  storage account. 
-                                  
+                                  storage account.
+
     The properties you should pay attention to are:
 
     - `allowed_subnet_keys` - (`list`, optional, defaults to `[]`) a list of keys pointing to Subnet definitions in the
@@ -344,9 +344,9 @@ variable "bootstrap_storages" {
                               Subnets described in `allowed_subnet_keys`.
 
     For detailed documentation see [module's documentation](../../modules/bootstrap/README.md#storage_network_security).
-                            
+
   - `file_shares_configuration` - (`map`, optional, defaults to `{}`) a map defining common File Share setting.
-                                  
+
     The properties you should pay attention to are:
 
     - `create_file_shares`            - (`bool`, optional, defaults to module default) controls if the File Shares defined in the
@@ -397,15 +397,15 @@ variable "bootstrap_storages" {
 
 variable "vmseries_universal" {
   description = <<-EOF
-  A map defining common settings for all created VM-Series instances. 
-  
+  A map defining common settings for all created VM-Series instances.
+
   It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
   However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
 
-  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
                           instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
@@ -500,13 +500,13 @@ variable "vmseries" {
 
     **Note!** \
     The `disable_password_authentication` property is by default `false` in this example. When using this value, you don't have
-    to specify anything but you can still additionally pass SSH keys for authentication. You can however set this property to 
+    to specify anything but you can still additionally pass SSH keys for authentication. You can however set this property to
     `true`, then you have to specify `ssh_keys` property.
 
     For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
   - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                         properties (mutually exclusive) that have to be set, either:
 
     - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -514,7 +514,7 @@ variable "vmseries" {
 
     For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#image).
 
-  - `virtual_machine` - (`map`, optional, defaults to module default) a map that groups most common VM configuration options. 
+  - `virtual_machine` - (`map`, optional, defaults to module default) a map that groups most common VM configuration options.
                         Most common properties are:
 
     - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
@@ -559,7 +559,7 @@ variable "vmseries" {
         **Note!** \
         Day0 configuration is **not meant** to be **secure**. It's here merely to help with the basic firewall setup. When
         `bootstrap_xml_template` is set, one of the following properties might be required.
-        
+
       - `data_snet_key`          - (`string`, required only when `bootstrap_xml_template` is set, defaults to `null`) a key
                                    pointing to a data Subnet definition in `var.vnets` (the `vnet_key` property is used to
                                    identify a VNET). The Subnet definition is used to calculate static routes for a data
@@ -570,7 +570,7 @@ variable "vmseries" {
       - `intranet_cidr`          - (`string`, optional, defaults to `null`) a CIDR of the Intranet - combined CIDR of all
                                    private networks. When set it will override the private Subnet CIDR for inbound traffic
                                    static routes.
-      
+
       For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#virtual_machine).
 
   - `interfaces`      - (`list`, required) configuration of all network interfaces. Order of the interfaces does matter - the
@@ -582,12 +582,12 @@ variable "vmseries" {
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                          the IP to change.
+                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                    the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
       - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -759,12 +759,12 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
     - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#subnets).
-    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the local VNet peering.
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering.  
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the remote VNet peering.
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -581,13 +581,13 @@ variable "vmseries" {
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                     skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                     to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                     the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -677,9 +677,9 @@ variable "vmseries" {
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -1120,7 +1120,15 @@ The most basic properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-  - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                        the IP to change.
+    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1209,17 +1217,20 @@ map(object({
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
 ```

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -947,16 +947,16 @@ Default value: `map[]`
 
 #### vmseries_universal
 
-A map defining common settings for all created VM-Series instances. 
-  
+A map defining common settings for all created VM-Series instances.
+
 It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
 However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
 
-- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1043,7 +1043,7 @@ The most basic properties are as follows:
   For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
 - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                       properties (mutually exclusive) that have to be set, either:
 
   - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -1123,12 +1123,12 @@ The most basic properties are as follows:
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                        the IP to change.
+                                  skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                  to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                  the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
     - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1267,12 +1267,12 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
   - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#subnets).
-  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the local VNet peering.
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering.  
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the remote VNet peering.
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -1122,13 +1122,13 @@ The most basic properties are as follows:
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                   skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                   to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                   the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1221,9 +1221,9 @@ map(object({
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_standalone/example.tfvars
+++ b/examples/vmseries_standalone/example.tfvars
@@ -119,9 +119,16 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name               = "primary-ip"
+            private_ip_address = "10.0.0.5"
+            create_public_ip   = true
+            primary            = true
+          }
+        }
       }
     ]
   }

--- a/examples/vmseries_standalone/example.tfvars
+++ b/examples/vmseries_standalone/example.tfvars
@@ -124,9 +124,9 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name               = "primary-ip"
+            primary            = true
             private_ip_address = "10.0.0.5"
             create_public_ip   = true
-            primary            = true
           }
         }
       }

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -448,16 +448,16 @@ module "vmseries" {
   interfaces = [for v in each.value.interfaces : {
     name      = "${var.name_prefix}${v.name}"
     subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
-      name             = ip_config_value.name
-      create_public_ip = ip_config_value.create_public_ip
-      public_ip_name = ip_config_value.create_public_ip ? "${
-        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
-      }" : ip_config_value.public_ip_name
-      primary                       = ip_config_value.primary
-      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
-      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
-      private_ip_address            = ip_config_value.private_ip_address
+    ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+      name             = vv.name
+      create_public_ip = vv.create_public_ip
+      public_ip_name = vv.create_public_ip ? "${
+        var.name_prefix}${coalesce(vv.public_ip_name, "${v.name}-${vv.name}-pip")
+      }" : vv.public_ip_name
+      primary                       = vv.primary
+      public_ip_resource_group_name = vv.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[vv.public_ip_key], null)
+      private_ip_address            = vv.private_ip_address
       }
     }
     attach_to_lb_backend_pool    = v.load_balancer_key != null

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -446,20 +446,24 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name                  = "${var.name_prefix}${v.name}"
-    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configuration_name = v.ip_configuration_name
-    create_public_ip      = v.create_public_ip
-    public_ip_name = v.create_public_ip ? "${
-      var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
-    }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    public_ip_id                  = try(module.public_ip.pip_ids[v.public_ip_key], null)
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
-    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
-    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
+    name      = "${var.name_prefix}${v.name}"
+    subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
+      name             = ip_config_value.name
+      create_public_ip = ip_config_value.create_public_ip
+      public_ip_name = ip_config_value.create_public_ip ? "${
+        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
+      }" : ip_config_value.public_ip_name
+      primary                       = ip_config_value.primary
+      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
+      private_ip_address            = ip_config_value.private_ip_address
+      }
+    }
+    attach_to_lb_backend_pool    = v.load_balancer_key != null
+    lb_backend_pool_id           = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -670,16 +670,16 @@ variable "bootstrap_storages" {
 
 variable "vmseries_universal" {
   description = <<-EOF
-  A map defining common settings for all created VM-Series instances. 
-  
+  A map defining common settings for all created VM-Series instances.
+
   It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
   However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
 
-  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -781,7 +781,7 @@ variable "vmseries" {
     For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
   - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                         properties (mutually exclusive) that have to be set, either:
 
     - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -861,12 +861,12 @@ variable "vmseries" {
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                          the IP to change.
+                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                    the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
       - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -1038,12 +1038,12 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
     - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#subnets).
-    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the local VNet peering.
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering.  
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the remote VNet peering.
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -858,7 +858,15 @@ variable "vmseries" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-    - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                          the IP to change.
+      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -945,17 +953,20 @@ variable "vmseries" {
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -860,13 +860,13 @@ variable "vmseries" {
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                     skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                     to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                     the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -957,9 +957,9 @@ variable "vmseries" {
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -1009,16 +1009,16 @@ Default value: `map[]`
 
 #### vmseries_universal
 
-A map defining common settings for all created VM-Series instances. 
-  
+A map defining common settings for all created VM-Series instances.
+
 It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
 However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
 
-- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1105,7 +1105,7 @@ The most basic properties are as follows:
   For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
 - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                       properties (mutually exclusive) that have to be set, either:
 
   - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -1185,12 +1185,12 @@ The most basic properties are as follows:
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                        the IP to change.
+                                  skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                  to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                  the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
     - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1329,12 +1329,12 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
   - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#subnets).
-  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the local VNet peering.
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering.  
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the remote VNet peering.
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -1184,13 +1184,13 @@ The most basic properties are as follows:
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                   skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                   to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                   the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1283,9 +1283,9 @@ map(object({
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -1182,7 +1182,15 @@ The most basic properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-  - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                        the IP to change.
+    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1271,17 +1279,20 @@ map(object({
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
 ```

--- a/examples/vmseries_transit_vnet_common/example.tfvars
+++ b/examples/vmseries_transit_vnet_common/example.tfvars
@@ -328,14 +328,26 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm01-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm01-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name                    = "vm01-public"
-        subnet_key              = "public"
-        create_public_ip        = true
+        name       = "vm01-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
         load_balancer_key       = "public"
         application_gateway_key = "public"
       },
@@ -343,6 +355,13 @@ vmseries = {
         name              = "vm01-private"
         subnet_key        = "private"
         load_balancer_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
       }
     ]
   }

--- a/examples/vmseries_transit_vnet_common/example.tfvars
+++ b/examples/vmseries_transit_vnet_common/example.tfvars
@@ -333,8 +333,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -344,8 +344,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
         load_balancer_key       = "public"
@@ -358,8 +358,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
       }
@@ -378,8 +378,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -389,8 +389,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
         load_balancer_key       = "public"
@@ -402,8 +402,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         load_balancer_key = "private"

--- a/examples/vmseries_transit_vnet_common/example.tfvars
+++ b/examples/vmseries_transit_vnet_common/example.tfvars
@@ -354,20 +354,39 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm02-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm02-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name                    = "vm02-public"
-        subnet_key              = "public"
-        create_public_ip        = true
+        name       = "vm02-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
         load_balancer_key       = "public"
         application_gateway_key = "public"
       },
       {
-        name              = "vm02-private"
-        subnet_key        = "private"
+        name       = "vm02-private"
+        subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         load_balancer_key = "private"
       },
     ]

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -448,16 +448,16 @@ module "vmseries" {
   interfaces = [for v in each.value.interfaces : {
     name      = "${var.name_prefix}${v.name}"
     subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
-      name             = ip_config_value.name
-      create_public_ip = ip_config_value.create_public_ip
-      public_ip_name = ip_config_value.create_public_ip ? "${
-        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
-      }" : ip_config_value.public_ip_name
-      primary                       = ip_config_value.primary
-      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
-      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
-      private_ip_address            = ip_config_value.private_ip_address
+    ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+      name             = vv.name
+      create_public_ip = vv.create_public_ip
+      public_ip_name = vv.create_public_ip ? "${
+        var.name_prefix}${coalesce(vv.public_ip_name, "${v.name}-${vv.name}-pip")
+      }" : vv.public_ip_name
+      primary                       = vv.primary
+      public_ip_resource_group_name = vv.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[vv.public_ip_key], null)
+      private_ip_address            = vv.private_ip_address
       }
     }
     attach_to_lb_backend_pool    = v.load_balancer_key != null

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -446,20 +446,24 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name                  = "${var.name_prefix}${v.name}"
-    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configuration_name = v.ip_configuration_name
-    create_public_ip      = v.create_public_ip
-    public_ip_name = v.create_public_ip ? "${
-      var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
-    }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    public_ip_id                  = try(module.public_ip.pip_ids[v.public_ip_key], null)
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
-    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
-    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
+    name      = "${var.name_prefix}${v.name}"
+    subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
+      name             = ip_config_value.name
+      create_public_ip = ip_config_value.create_public_ip
+      public_ip_name = ip_config_value.create_public_ip ? "${
+        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
+      }" : ip_config_value.public_ip_name
+      primary                       = ip_config_value.primary
+      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
+      private_ip_address            = ip_config_value.private_ip_address
+      }
+    }
+    attach_to_lb_backend_pool    = v.load_balancer_key != null
+    lb_backend_pool_id           = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -670,16 +670,16 @@ variable "bootstrap_storages" {
 
 variable "vmseries_universal" {
   description = <<-EOF
-  A map defining common settings for all created VM-Series instances. 
-  
+  A map defining common settings for all created VM-Series instances.
+
   It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
   However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
 
-  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -781,7 +781,7 @@ variable "vmseries" {
     For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
   - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                         properties (mutually exclusive) that have to be set, either:
 
     - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -861,12 +861,12 @@ variable "vmseries" {
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                          the IP to change.
+                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                    the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
       - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -1038,12 +1038,12 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
     - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#subnets).
-    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the local VNet peering.
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering.  
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the remote VNet peering.
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -858,7 +858,15 @@ variable "vmseries" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-    - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                          the IP to change.
+      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -945,17 +953,20 @@ variable "vmseries" {
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -860,13 +860,13 @@ variable "vmseries" {
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                     skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                     to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                     the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -957,9 +957,9 @@ variable "vmseries" {
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -1192,7 +1192,10 @@ The basic Scale Set configuration properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`.
-  - `create_public_ip`        - (`bool`, optional, defaults to module default) create Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+      - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                 `var.loadbalancers` variable, network interface that has this property defined will be added to
                                 the Load Balancer's backend pool.
@@ -1291,16 +1294,20 @@ map(object({
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                           = string
-      subnet_key                     = string
-      create_public_ip               = optional(bool)
-      pip_domain_name_label          = optional(string)
-      pip_idle_timeout_in_minutes    = optional(number)
-      pip_prefix_name                = optional(string)
-      pip_prefix_resource_group_name = optional(string)
-      pip_prefix_id                  = optional(string)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = optional(map(object({
+        name                           = optional(string)
+        primary                        = optional(bool, true)
+        create_public_ip               = optional(bool, false)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        pip_prefix_id                  = optional(string)
+      })))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -1194,8 +1194,8 @@ The basic Scale Set configuration properties are as follows:
                                 `var.vnets`.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-      - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
       - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+      - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                 `var.loadbalancers` variable, network interface that has this property defined will be added to
                                 the Load Balancer's backend pool.

--- a/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
@@ -337,21 +337,40 @@ scale_sets = {
     }
     interfaces = [
       {
-        name             = "management"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "management"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = true
+          }
+        }
       },
       {
         name                    = "public"
         subnet_key              = "public"
         load_balancer_key       = "public"
         application_gateway_key = "public"
-        create_public_ip        = true
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = true
+          }
+        }
       },
       {
         name              = "private"
         subnet_key        = "private"
         load_balancer_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       }
     ]
     autoscaling_profiles = [

--- a/examples/vmseries_transit_vnet_common_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/main.tf
@@ -422,15 +422,19 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name                           = v.name
-      subnet_id                      = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-      create_public_ip               = v.create_public_ip
-      pip_domain_name_label          = v.pip_domain_name_label
-      pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
-      pip_prefix_name                = v.pip_prefix_name
-      pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
-      lb_backend_pool_ids            = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
-      appgw_backend_pool_ids         = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
+      name      = v.name
+      subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+      ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+        name                           = vv.name
+        primary                        = vv.primary
+        create_public_ip               = vv.create_public_ip
+        pip_domain_name_label          = vv.pip_domain_name_label
+        pip_idle_timeout_in_minutes    = vv.pip_idle_timeout_in_minutes
+        pip_prefix_name                = vv.pip_prefix_name
+        pip_prefix_resource_group_name = vv.pip_prefix_resource_group_name
+      } }
+      lb_backend_pool_ids    = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
+      appgw_backend_pool_ids = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
     }
   ]
 

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -825,7 +825,10 @@ variable "scale_sets" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`.
-    - `create_public_ip`        - (`bool`, optional, defaults to module default) create Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+        - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+        - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+        - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                   `var.loadbalancers` variable, network interface that has this property defined will be added to
                                   the Load Balancer's backend pool.
@@ -922,16 +925,20 @@ variable "scale_sets" {
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                           = string
-      subnet_key                     = string
-      create_public_ip               = optional(bool)
-      pip_domain_name_label          = optional(string)
-      pip_idle_timeout_in_minutes    = optional(number)
-      pip_prefix_name                = optional(string)
-      pip_prefix_resource_group_name = optional(string)
-      pip_prefix_id                  = optional(string)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = optional(map(object({
+        name                           = optional(string)
+        primary                        = optional(bool, true)
+        create_public_ip               = optional(bool, false)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        pip_prefix_id                  = optional(string)
+      })))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -827,8 +827,8 @@ variable "scale_sets" {
                                   `var.vnets`.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
         - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-        - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
         - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+        - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                   `var.loadbalancers` variable, network interface that has this property defined will be added to
                                   the Load Balancer's backend pool.

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -1013,16 +1013,16 @@ Default value: `map[]`
 
 #### vmseries_universal
 
-A map defining common settings for all created VM-Series instances. 
-  
+A map defining common settings for all created VM-Series instances.
+
 It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
 However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
 universal properties can be overriden on a per-VM basis.
 
 Following properties are supported:
 
-- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+- `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1109,7 +1109,7 @@ The most basic properties are as follows:
   For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
 - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                      required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                       properties (mutually exclusive) that have to be set, either:
 
   - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -1189,12 +1189,12 @@ The most basic properties are as follows:
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                        the IP to change.
+                                  skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                  to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                  the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
     - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1333,12 +1333,12 @@ Following properties are supported:
                                 [VNET module documentation](../../modules/vnet/README.md#route_tables).
   - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                 [VNET module documentation](../../modules/vnet/README.md#subnets).
-  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the local VNet peering. 
+  - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the local VNet peering.
   - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                `use_remote_gateways` parameters on the remote VNet peering.  
+                                set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                `use_remote_gateways` parameters on the remote VNet peering.
 
   For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -1186,7 +1186,15 @@ The most basic properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-  - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                        the IP to change.
+    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1275,17 +1283,20 @@ map(object({
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
 ```

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -1188,13 +1188,13 @@ The most basic properties are as follows:
                                 `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                   skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                   to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                   the IP to change.
     - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                  **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                 variable, network interface that has this property defined will be added to the Load Balancer's
                                 backend pool.
@@ -1287,9 +1287,9 @@ map(object({
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated/example.tfvars
@@ -265,8 +265,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -276,8 +276,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
         load_balancer_key = "public"
@@ -349,8 +349,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -360,8 +360,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         load_balancer_key = "public"
@@ -372,8 +372,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
       }
@@ -433,8 +433,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -444,8 +444,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -455,8 +455,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         load_balancer_key = "private"
@@ -517,8 +517,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -528,8 +528,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = true
             primary          = true
+            create_public_ip = true
           }
         }
       },
@@ -539,8 +539,8 @@ vmseries = {
         ip_configurations = {
           primary-ip = {
             name             = "primary-ip"
-            create_public_ip = false
             primary          = true
+            create_public_ip = false
           }
         }
         load_balancer_key = "private"

--- a/examples/vmseries_transit_vnet_dedicated/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated/example.tfvars
@@ -260,19 +260,38 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm-in-01-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm-in-01-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name              = "vm-in-01-public"
-        subnet_key        = "public"
-        create_public_ip  = true
+        name       = "vm-in-01-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
         load_balancer_key = "public"
       },
       {
         name       = "vm-in-01-private"
         subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       }
     ]
   }
@@ -325,18 +344,38 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm-in-02-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm-in-02-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name              = "vm-in-02-public"
-        subnet_key        = "public"
+        name       = "vm-in-02-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         load_balancer_key = "public"
       },
       {
         name       = "vm-in-02-private"
         subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
       }
     ]
   }
@@ -389,18 +428,37 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm-obew-01-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm-obew-01-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name             = "vm-obew-01-public"
-        subnet_key       = "public"
-        create_public_ip = true
+        name       = "vm-obew-01-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name              = "vm-obew-01-private"
-        subnet_key        = "private"
+        name       = "vm-obew-01-private"
+        subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         load_balancer_key = "private"
       }
     ]
@@ -454,18 +512,37 @@ vmseries = {
     }
     interfaces = [
       {
-        name             = "vm-obew-02-mgmt"
-        subnet_key       = "management"
-        create_public_ip = true
+        name       = "vm-obew-02-mgmt"
+        subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name             = "vm-obew-02-public"
-        subnet_key       = "public"
-        create_public_ip = true
+        name       = "vm-obew-02-public"
+        subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = true
+            primary          = true
+          }
+        }
       },
       {
-        name              = "vm-obew-02-private"
-        subnet_key        = "private"
+        name       = "vm-obew-02-private"
+        subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            create_public_ip = false
+            primary          = true
+          }
+        }
         load_balancer_key = "private"
       }
     ]

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -448,16 +448,16 @@ module "vmseries" {
   interfaces = [for v in each.value.interfaces : {
     name      = "${var.name_prefix}${v.name}"
     subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
-      name             = ip_config_value.name
-      create_public_ip = ip_config_value.create_public_ip
-      public_ip_name = ip_config_value.create_public_ip ? "${
-        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
-      }" : ip_config_value.public_ip_name
-      primary                       = ip_config_value.primary
-      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
-      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
-      private_ip_address            = ip_config_value.private_ip_address
+    ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+      name             = vv.name
+      create_public_ip = vv.create_public_ip
+      public_ip_name = vv.create_public_ip ? "${
+        var.name_prefix}${coalesce(vv.public_ip_name, "${v.name}-${vv.name}-pip")
+      }" : vv.public_ip_name
+      primary                       = vv.primary
+      public_ip_resource_group_name = vv.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[vv.public_ip_key], null)
+      private_ip_address            = vv.private_ip_address
       }
     }
     attach_to_lb_backend_pool    = v.load_balancer_key != null

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -446,20 +446,24 @@ module "vmseries" {
   )
 
   interfaces = [for v in each.value.interfaces : {
-    name                  = "${var.name_prefix}${v.name}"
-    subnet_id             = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-    ip_configuration_name = v.ip_configuration_name
-    create_public_ip      = v.create_public_ip
-    public_ip_name = v.create_public_ip ? "${
-      var.name_prefix}${coalesce(v.public_ip_name, "${v.name}-pip")
-    }" : v.public_ip_name
-    public_ip_resource_group_name = v.public_ip_resource_group_name
-    public_ip_id                  = try(module.public_ip.pip_ids[v.public_ip_key], null)
-    private_ip_address            = v.private_ip_address
-    attach_to_lb_backend_pool     = v.load_balancer_key != null
-    lb_backend_pool_id            = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
-    attach_to_appgw_backend_pool  = v.appgw_backend_pool_id != null
-    appgw_backend_pool_id         = try(v.appgw_backend_pool_id, null)
+    name      = "${var.name_prefix}${v.name}"
+    subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+    ip_configurations = { for ip_config_key, ip_config_value in v.ip_configurations : ip_config_key => {
+      name             = ip_config_value.name
+      create_public_ip = ip_config_value.create_public_ip
+      public_ip_name = ip_config_value.create_public_ip ? "${
+        var.name_prefix}${coalesce(ip_config_value.public_ip_name, "${v.name}-${ip_config_value.name}-pip")
+      }" : ip_config_value.public_ip_name
+      primary                       = ip_config_value.primary
+      public_ip_resource_group_name = ip_config_value.public_ip_resource_group_name
+      public_ip_id                  = try(module.public_ip.pip_ids[ip_config_value.public_ip_key], null)
+      private_ip_address            = ip_config_value.private_ip_address
+      }
+    }
+    attach_to_lb_backend_pool    = v.load_balancer_key != null
+    lb_backend_pool_id           = try(module.load_balancer[v.load_balancer_key].backend_pool_id, null)
+    attach_to_appgw_backend_pool = v.appgw_backend_pool_id != null
+    appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
   tags = var.tags

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -670,16 +670,16 @@ variable "bootstrap_storages" {
 
 variable "vmseries_universal" {
   description = <<-EOF
-  A map defining common settings for all created VM-Series instances. 
-  
+  A map defining common settings for all created VM-Series instances.
+
   It duplicates popular properties from `vmseries` variable, specifically `vmseries.image` and `vmseries.virtual_machine` maps.
   However, if values are set in those maps, they still take precedence over the ones set within this variable. As a result, all
   universal properties can be overriden on a per-VM basis.
 
   Following properties are supported:
 
-  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
+  - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -781,7 +781,7 @@ variable "vmseries" {
     For all properties and their default values see [module's documentation](../../modules/vmseries/README.md#authentication).
 
   - `image`           - (`map`, optional) properties defining a base image used by the deployed VM. The `image` property is
-                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2 
+                        required (if no common properties were set within `vmseries_universal` variable) but there are only 2
                         properties (mutually exclusive) that have to be set, either:
 
     - `version`   - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
@@ -861,12 +861,12 @@ variable "vmseries" {
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                          the IP to change.
+                                    skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                    to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                    the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
       - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -1038,12 +1038,12 @@ variable "test_infrastructure" {
                                   [VNET module documentation](../../modules/vnet/README.md#route_tables).
     - `subnets`                 - (`map`, optional) map of Subnets to create or source, for details see
                                   [VNET module documentation](../../modules/vnet/README.md#subnets).
-    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to 
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the local VNet peering. 
+    - `local_peer_config`       - (`map`, optional) a map that contains local peer configuration parameters. This value allows to
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the local VNet peering.
     - `remote_peer_config`      - (`map`, optional) a map that contains remote peer configuration parameters. This value allows to
-                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and 
-                                  `use_remote_gateways` parameters on the remote VNet peering.  
+                                  set `allow_virtual_network_access`, `allow_forwarded_traffic`, `allow_gateway_transit` and
+                                  `use_remote_gateways` parameters on the remote VNet peering.
 
     For all properties and their default values see [module's documentation](../../modules/test_infrastructure/README.md#vnets).
 

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -858,7 +858,15 @@ variable "vmseries" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
-    - `create_public_ip`        - (`bool`, optional, defaults to `false`) create a Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                          skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                          to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                          the IP to change.
+      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                          **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -945,17 +953,20 @@ variable "vmseries" {
       identity_ids                  = optional(list(string))
     })
     interfaces = list(object({
-      name                          = string
-      subnet_key                    = string
-      ip_configuration_name         = optional(string)
-      create_public_ip              = optional(bool, false)
-      public_ip_name                = optional(string)
-      public_ip_resource_group_name = optional(string)
-      public_ip_key                 = optional(string)
-      private_ip_address            = optional(string)
-      load_balancer_key             = optional(string)
-      application_gateway_key       = optional(string)
-      appgw_backend_pool_id         = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = map(object({
+        name                          = optional(string)
+        create_public_ip              = optional(bool, false)
+        public_ip_name                = optional(string)
+        primary                       = optional(bool, true)
+        public_ip_resource_group_name = optional(string)
+        public_ip_key                 = optional(string)
+        private_ip_address            = optional(string)
+      }))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
+      appgw_backend_pool_id   = optional(string)
     }))
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -860,13 +860,13 @@ variable "vmseries" {
                                   `var.vnets`. Key identifying the VNET is defined in `virtual_machine.vnet_key` property.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
       - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
       - `private_ip_address`      - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
                                     skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
                                     to change as long as the VM is running. Any stop/deallocate/restart operation might cause
                                     the IP to change.
       - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
-                                    **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in `var.loadbalancers`
                                   variable, network interface that has this property defined will be added to the Load Balancer's
                                   backend pool.
@@ -957,9 +957,9 @@ variable "vmseries" {
       subnet_key = string
       ip_configurations = map(object({
         name                          = optional(string)
+        primary                       = optional(bool, true)
         create_public_ip              = optional(bool, false)
         public_ip_name                = optional(string)
-        primary                       = optional(bool, true)
         public_ip_resource_group_name = optional(string)
         public_ip_key                 = optional(string)
         private_ip_address            = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -1009,7 +1009,7 @@ set within this variable. As a result, all universal properties can be overriden
 Following properties are supported:
 
 - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                        instead of the one passed to the module and version for `airs-flex` offer must be provided.
+                        instead of the one passed to the module and version for `airs-flex` offer must be provided.  
 - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
 - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -1187,9 +1187,9 @@ The basic Scale Set configuration properties are as follows:
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`.
   - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
-    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+      - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+      - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                 `var.loadbalancers` variable, network interface that has this property defined will be added to
                                 the Load Balancer's backend pool.

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -1186,7 +1186,10 @@ The basic Scale Set configuration properties are as follows:
   - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
   - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                 `var.vnets`.
-  - `create_public_ip`        - (`bool`, optional, defaults to module default) create Public IP for an interface.
+  - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+    - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
   - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                 `var.loadbalancers` variable, network interface that has this property defined will be added to
                                 the Load Balancer's backend pool.
@@ -1285,16 +1288,20 @@ map(object({
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                           = string
-      subnet_key                     = string
-      create_public_ip               = optional(bool)
-      pip_domain_name_label          = optional(string)
-      pip_idle_timeout_in_minutes    = optional(number)
-      pip_prefix_name                = optional(string)
-      pip_prefix_resource_group_name = optional(string)
-      pip_prefix_id                  = optional(string)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = optional(map(object({
+        name                           = optional(string)
+        primary                        = optional(bool, true)
+        create_public_ip               = optional(bool, false)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        pip_prefix_id                  = optional(string)
+      })))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
@@ -283,15 +283,36 @@ scale_sets = {
       {
         name       = "management"
         subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       },
       {
         name              = "public"
         subnet_key        = "public"
         load_balancer_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       },
       {
         name       = "private"
         subnet_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       }
     ]
   }
@@ -352,15 +373,36 @@ scale_sets = {
       {
         name       = "management"
         subnet_key = "management"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       },
       {
         name       = "public"
         subnet_key = "public"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       },
       {
         name              = "private"
         subnet_key        = "private"
         load_balancer_key = "private"
+        ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+          }
+        }
       }
     ]
   }

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
@@ -422,15 +422,19 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name                           = v.name
-      subnet_id                      = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
-      create_public_ip               = v.create_public_ip
-      pip_domain_name_label          = v.pip_domain_name_label
-      pip_idle_timeout_in_minutes    = v.pip_idle_timeout_in_minutes
-      pip_prefix_name                = v.pip_prefix_name
-      pip_prefix_resource_group_name = v.pip_prefix_resource_group_name
-      lb_backend_pool_ids            = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
-      appgw_backend_pool_ids         = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
+      name      = v.name
+      subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
+      ip_configurations = { for vk, vv in v.ip_configurations : vk => {
+        name                           = vv.name
+        primary                        = vv.primary
+        create_public_ip               = vv.create_public_ip
+        pip_domain_name_label          = vv.pip_domain_name_label
+        pip_idle_timeout_in_minutes    = vv.pip_idle_timeout_in_minutes
+        pip_prefix_name                = vv.pip_prefix_name
+        pip_prefix_resource_group_name = vv.pip_prefix_resource_group_name
+      } }
+      lb_backend_pool_ids    = try([module.load_balancer[v.load_balancer_key].backend_pool_id], [])
+      appgw_backend_pool_ids = try([module.appgw[v.application_gateway_key].backend_pool_id], [])
     }
   ]
 

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -825,7 +825,10 @@ variable "scale_sets" {
     - `name`                    - (`string`, required) name of the network interface (will be prefixed with `var.name_prefix`).
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`.
-    - `create_public_ip`        - (`bool`, optional, defaults to module default) create Public IP for an interface.
+    - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
+      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                   `var.loadbalancers` variable, network interface that has this property defined will be added to
                                   the Load Balancer's backend pool.
@@ -922,16 +925,20 @@ variable "scale_sets" {
       webhooks_uris           = optional(map(string), {})
     }), {})
     interfaces = list(object({
-      name                           = string
-      subnet_key                     = string
-      create_public_ip               = optional(bool)
-      pip_domain_name_label          = optional(string)
-      pip_idle_timeout_in_minutes    = optional(number)
-      pip_prefix_name                = optional(string)
-      pip_prefix_resource_group_name = optional(string)
-      pip_prefix_id                  = optional(string)
-      load_balancer_key              = optional(string)
-      application_gateway_key        = optional(string)
+      name       = string
+      subnet_key = string
+      ip_configurations = optional(map(object({
+        name                           = optional(string)
+        primary                        = optional(bool, true)
+        create_public_ip               = optional(bool, false)
+        pip_domain_name_label          = optional(string)
+        pip_idle_timeout_in_minutes    = optional(number)
+        pip_prefix_name                = optional(string)
+        pip_prefix_resource_group_name = optional(string)
+        pip_prefix_id                  = optional(string)
+      })))
+      load_balancer_key       = optional(string)
+      application_gateway_key = optional(string)
     }))
     autoscaling_profiles = optional(list(object({
       name          = string

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -656,7 +656,7 @@ variable "scale_sets_universal" {
   Following properties are supported:
 
   - `use_airs`          - (`bool`, optional, defaults to `false`) when set to `true`, the AI Runtime Security VM image is used 
-                          instead of the one passed to the module and version for `airs-flex` offer must be provided.
+                          instead of the one passed to the module and version for `airs-flex` offer must be provided.  
   - `version`           - (`string`, optional) describes the PAN-OS image version from Azure Marketplace.
   - `size`              - (`string`, optional, defaults to module default) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -826,9 +826,9 @@ variable "scale_sets" {
     - `subnet_key`              - (`string`, required) a key of a subnet to which the interface will be assigned as defined in
                                   `var.vnets`.
     - `ip_configurations`       - (`map`, required) A map that contains the IP configurations for the interface.
-      - `name`                    - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-      - `create_public_ip`        - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-      - `primary`                 - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+        - `name`                  - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+        - `primary`               - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+        - `create_public_ip`      - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
     - `load_balancer_key`       - (`string`, optional, defaults to `null`) key of a Load Balancer defined in the
                                   `var.loadbalancers` variable, network interface that has this property defined will be added to
                                   the Load Balancer's backend pool.

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -275,12 +275,13 @@ Following configuration options are available:
 - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
 - ip_configurations               - (`map`, required) A map that contains the IP configurations for the interface.
   - `name`                          - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-  - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                      skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                      to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                      the IP to change.
+  - `primary`                       - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary
+                                      one.
+  - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. 
+                                      When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                      guaranteed not to change as long as the VM is running. Any stop/deallocate/restart
+                                      operation might cause the IP to change.
   - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-  - `primary`                       - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
                                       **Note!** When you define multiple IP configurations, exactly one must be the primary.
   - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
                                       interface. When `create_public_ip` is set to `true` this will become a name of a newly
@@ -311,8 +312,8 @@ Example:
     ip_configurations = {
       primary-ip = {
         name = "primary-ip"
-        create_public_ip      = true
         primary               = true
+        create_public_ip      = true
         public_ip_name       = "fw-mgmt-pip"
       }
   },
@@ -325,8 +326,8 @@ Example:
     ip_configurations = {
       primary-ip = {
         name = "primary-ip"
-        create_public_ip      = false
         primary               = true
+        create_public_ip      = false
         public_ip_name        = "fw-public-pip"
       }
   },
@@ -339,15 +340,15 @@ Example:
     ip_configurations = {
       primary-ip = {
         name = "primary-ip"
-        create_public_ip      = false
         primary               = true
+        create_public_ip      = false
         private_ip_address    = "10.0.0.5"
         public_ip_name        = "fw-public-pip"
       },
       secondary-ip = {
         name = "secondary-ip"
-        create_public_ip      = false
         primary               = false
+        create_public_ip      = false
         private_ip_address    = "10.0.0.6"
         public_ip_name        = "fw-public-pip"
       }

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -190,7 +190,7 @@ Firewall parameters configuration.
 This map contains basic, as well as some optional Firewall parameters. Both types contain sane defaults.
 Nevertheless they should be at least reviewed to meet deployment requirements.
 
-List of either required or important properties: 
+List of either required or important properties:
 
 - `size`              - (`string`, optional, defaults to `Standard_D3_v2`) Azure VM size (type). Consult the *VM-Series
                         Deployment Guide* as only a few selected sizes are supported.
@@ -209,7 +209,7 @@ List of either required or important properties:
 
   For more details on bootstrapping [see documentation](https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components).
 
-List of other, optional properties: 
+List of other, optional properties:
 
 - `avset_id`                      - (`string`, optional, default to `null`) identifier of the Availability Set to use.
 - `capacity_reservation_group_id` - (`string`, optional, defaults to `null`) specifies the ID of the Capacity Reservation Group
@@ -228,7 +228,7 @@ List of other, optional properties:
 - `identity_type`                 - (`string`, optional, defaults to `SystemAssigned`) type of Managed Service Identity that
                                     should be configured on this VM. Can be one of "SystemAssigned", "UserAssigned" or
                                     "SystemAssigned, UserAssigned".
-- `identity_ids`                  - (`list`, optional, defaults to `[]`) a list of User Assigned Managed Identity IDs to be 
+- `identity_ids`                  - (`list`, optional, defaults to `[]`) a list of User Assigned Managed Identity IDs to be
                                     assigned to this VM. Required only if `identity_type` is not "SystemAssigned".
 
 
@@ -268,7 +268,7 @@ Interfaces will be attached to VM in the order you define here, therefore:
 
 - The first should be the management interface, which does not participate in data filtering.
 - The remaining ones are the dataplane interfaces.
-  
+
 Following configuration options are available:
 
 - `name`                          - (`string`, required) the interface name.
@@ -287,7 +287,7 @@ Following configuration options are available:
                                       created Public IP interface. Otherwise this is a name of an existing interfaces that will
                                       be sourced and attached to the interface. Not used when using `public_ip` module.
   - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                      contains public IP that that will be associated with the interface. Used only when 
+                                      contains public IP that that will be associated with the interface. Used only when
                                       `create_public_ip` is `false`.
   - `public_ip_id`                  - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
                                       interface. Property is used when public IP is not created or sourced within this module.
@@ -347,7 +347,7 @@ Example:
       secondary-ip = {
         name = "secondary-ip"
         create_public_ip      = false
-        primary               = true
+        primary               = false
         private_ip_address    = "10.0.0.6"
         public_ip_name        = "fw-public-pip"
       }
@@ -364,10 +364,10 @@ list(object({
     subnet_id = string
     ip_configurations = map(object({
       name                          = optional(string, "primary")
+      primary                       = optional(bool, true)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)
-      primary                       = optional(bool, true)
       public_ip_id                  = optional(string)
       private_ip_address            = optional(string)
     }))

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -58,7 +58,11 @@ resource "azurerm_network_interface" "this" {
       primary                       = ip_configuration.value.primary
       public_ip_address_id = try(coalesce(
         ip_configuration.value.public_ip_id,
-        try(azurerm_public_ip.this["${each.value.name}-${ip_configuration.key}"].id, data.azurerm_public_ip.this["${each.value.name}-${ip_configuration.key}"].id, null)
+        try(
+          azurerm_public_ip.this["${each.value.name}-${ip_configuration.key}"].id,
+          data.azurerm_public_ip.this["${each.value.name}-${ip_configuration.key}"].id,
+          null
+        )
       ), null)
     }
   }

--- a/modules/vmseries/outputs.tf
+++ b/modules/vmseries/outputs.tf
@@ -3,7 +3,11 @@ output "mgmt_ip_address" {
   VM-Series management IP address. If `create_public_ip` was `true`, it is a public IP address, otherwise a private IP address.
   EOF
   value = try(
-    azurerm_public_ip.this[var.interfaces[0].name].ip_address,
+    {
+      for config_key, config_value in var.interfaces[0].ip_configurations : config_key => {
+        public_ip = azurerm_public_ip.this["${var.interfaces[0].name}-${config_key}"].ip_address
+      }
+    },
     azurerm_network_interface.this[var.interfaces[0].name].ip_configuration[0].private_ip_address
   )
 }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -205,12 +205,13 @@ variable "interfaces" {
   - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
   - ip_configurations               - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                          - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-    - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                        the IP to change.
+    - `primary`                       - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary
+                                        one.
+    - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. 
+                                        When skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is
+                                        guaranteed not to change as long as the VM is running. Any stop/deallocate/restart
+                                        operation might cause the IP to change.
     - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-    - `primary`                       - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
                                         **Note!** When you define multiple IP configurations, exactly one must be the primary.
     - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
                                         interface. When `create_public_ip` is set to `true` this will become a name of a newly
@@ -241,8 +242,8 @@ variable "interfaces" {
       ip_configurations = {
         primary-ip = {
           name = "primary-ip"
-          create_public_ip      = true
           primary               = true
+          create_public_ip      = true
           public_ip_name       = "fw-mgmt-pip"
         }
     },
@@ -255,8 +256,8 @@ variable "interfaces" {
       ip_configurations = {
         primary-ip = {
           name = "primary-ip"
-          create_public_ip      = false
           primary               = true
+          create_public_ip      = false
           public_ip_name        = "fw-public-pip"
         }
     },
@@ -269,15 +270,15 @@ variable "interfaces" {
       ip_configurations = {
         primary-ip = {
           name = "primary-ip"
-          create_public_ip      = false
           primary               = true
+          create_public_ip      = false
           private_ip_address    = "10.0.0.5"
           public_ip_name        = "fw-public-pip"
         },
         secondary-ip = {
           name = "secondary-ip"
-          create_public_ip      = false
           primary               = false
+          create_public_ip      = false
           private_ip_address    = "10.0.0.6"
           public_ip_name        = "fw-public-pip"
         }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -97,7 +97,7 @@ variable "virtual_machine" {
   This map contains basic, as well as some optional Firewall parameters. Both types contain sane defaults.
   Nevertheless they should be at least reviewed to meet deployment requirements.
 
-  List of either required or important properties: 
+  List of either required or important properties:
 
   - `size`              - (`string`, optional, defaults to `Standard_D3_v2`) Azure VM size (type). Consult the *VM-Series
                           Deployment Guide* as only a few selected sizes are supported.
@@ -116,7 +116,7 @@ variable "virtual_machine" {
 
     For more details on bootstrapping [see documentation](https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/create-the-init-cfgtxt-file/init-cfgtxt-file-components).
 
-  List of other, optional properties: 
+  List of other, optional properties:
 
   - `avset_id`                      - (`string`, optional, default to `null`) identifier of the Availability Set to use.
   - `capacity_reservation_group_id` - (`string`, optional, defaults to `null`) specifies the ID of the Capacity Reservation Group
@@ -135,7 +135,7 @@ variable "virtual_machine" {
   - `identity_type`                 - (`string`, optional, defaults to `SystemAssigned`) type of Managed Service Identity that
                                       should be configured on this VM. Can be one of "SystemAssigned", "UserAssigned" or
                                       "SystemAssigned, UserAssigned".
-  - `identity_ids`                  - (`list`, optional, defaults to `[]`) a list of User Assigned Managed Identity IDs to be 
+  - `identity_ids`                  - (`list`, optional, defaults to `[]`) a list of User Assigned Managed Identity IDs to be
                                       assigned to this VM. Required only if `identity_type` is not "SystemAssigned".
   EOF
   type = object({
@@ -198,7 +198,7 @@ variable "interfaces" {
 
   - The first should be the management interface, which does not participate in data filtering.
   - The remaining ones are the dataplane interfaces.
-  
+
   Following configuration options are available:
 
   - `name`                          - (`string`, required) the interface name.
@@ -217,7 +217,7 @@ variable "interfaces" {
                                         created Public IP interface. Otherwise this is a name of an existing interfaces that will
                                         be sourced and attached to the interface. Not used when using `public_ip` module.
     - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                        contains public IP that that will be associated with the interface. Used only when 
+                                        contains public IP that that will be associated with the interface. Used only when
                                         `create_public_ip` is `false`.
     - `public_ip_id`                  - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
                                         interface. Property is used when public IP is not created or sourced within this module.
@@ -277,7 +277,7 @@ variable "interfaces" {
         secondary-ip = {
           name = "secondary-ip"
           create_public_ip      = false
-          primary               = true
+          primary               = false
           private_ip_address    = "10.0.0.6"
           public_ip_name        = "fw-public-pip"
         }
@@ -290,10 +290,10 @@ variable "interfaces" {
     subnet_id = string
     ip_configurations = map(object({
       name                          = optional(string, "primary")
+      primary                       = optional(bool, true)
       create_public_ip              = optional(bool, false)
       public_ip_name                = optional(string)
       public_ip_resource_group_name = optional(string)
-      primary                       = optional(bool, true)
       public_ip_id                  = optional(string)
       private_ip_address            = optional(string)
     }))

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -203,21 +203,24 @@ variable "interfaces" {
 
   - `name`                          - (`string`, required) the interface name.
   - `subnet_id`                     - (`string`, required) ID of an existing subnet to create the interface in.
-  - `ip_configuration_name`         - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
-  - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
-                                      skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
-                                      to change as long as the VM is running. Any stop/deallocate/restart operation might cause
-                                      the IP to change.
-  - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
-  - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
-                                      interface. When `create_public_ip` is set to `true` this will become a name of a newly
-                                      created Public IP interface. Otherwise this is a name of an existing interfaces that will
-                                      be sourced and attached to the interface. Not used when using `public_ip` module.
-  - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
-                                      contains public IP that that will be associated with the interface. Used only when 
-                                      `create_public_ip` is `false`.
-  - `public_ip_id`                  - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
-                                      interface. Property is used when public IP is not created or sourced within this module.
+  - ip_configurations               - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                          - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `private_ip_address`            - (`string`, optional, defaults to `null`) static private IP to assign to the interface. When
+                                        skipped Azure will assign one dynamically. Keep in mind that a dynamic IP is guarantied not
+                                        to change as long as the VM is running. Any stop/deallocate/restart operation might cause
+                                        the IP to change.
+    - `create_public_ip`              - (`bool`, optional, defaults to `false`) if `true`, creates a public IP for the interface.
+    - `primary`                       - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+                                        **Note!** When you define multiple IP configurations, exactly one must be the primary.
+    - `public_ip_name`                - (`string`, optional, defaults to `null`) name of the public IP to associate with the
+                                        interface. When `create_public_ip` is set to `true` this will become a name of a newly
+                                        created Public IP interface. Otherwise this is a name of an existing interfaces that will
+                                        be sourced and attached to the interface. Not used when using `public_ip` module.
+    - `public_ip_resource_group_name` - (`string`, optional, defaults to `var.resource_group_name`) name of a Resource Group that
+                                        contains public IP that that will be associated with the interface. Used only when 
+                                        `create_public_ip` is `false`.
+    - `public_ip_id`                  - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
+                                        interface. Property is used when public IP is not created or sourced within this module.
   - `attach_to_lb_backend_pool`     - (`bool`, optional, defaults to `false`) set to `true` if you would like to associate this
                                       interface with a Load Balancer backend pool.
   - `lb_backend_pool_id`            - (`string`, optional, defaults to `null`) ID of an existing backend pool to associate the
@@ -235,8 +238,13 @@ variable "interfaces" {
     {
       name                 = "fw-mgmt"
       subnet_id            = azurerm_subnet.my_mgmt_subnet.id
-      public_ip_name       = "fw-mgmt-pip"
-      create_public_ip     = true
+      ip_configurations = {
+        primary-ip = {
+          name = "primary-ip"
+          create_public_ip      = true
+          primary               = true
+          public_ip_name       = "fw-mgmt-pip"
+        }
     },
     # public interface reusing an existing public IP resource
     {
@@ -244,40 +252,89 @@ variable "interfaces" {
       subnet_id                 = azurerm_subnet.my_pub_subnet.id
       attach_to_lb_backend_pool = true
       lb_backend_pool_id        = module.inbound_lb.backend_pool_id
-      create_public_ip          = false
-      public_ip_name            = "fw-public-pip"
+      ip_configurations = {
+        primary-ip = {
+          name = "primary-ip"
+          create_public_ip      = false
+          primary               = true
+          public_ip_name        = "fw-public-pip"
+        }
+    },
+    # interface with 2 IP addresses
+    {
+      name                      = "fw-two-ips"
+      subnet_id                 = azurerm_subnet.my_pub_subnet.id
+      attach_to_lb_backend_pool = true
+      lb_backend_pool_id        = module.inbound_lb.backend_pool_id
+      ip_configurations = {
+        primary-ip = {
+          name = "primary-ip"
+          create_public_ip      = false
+          primary               = true
+          private_ip_address    = "10.0.0.5"
+          public_ip_name        = "fw-public-pip"
+        },
+        secondary-ip = {
+          name = "secondary-ip"
+          create_public_ip      = false
+          primary               = true
+          private_ip_address    = "10.0.0.6"
+          public_ip_name        = "fw-public-pip"
+        }
     },
   ]
   ```
   EOF
   type = list(object({
-    name                          = string
-    subnet_id                     = string
-    ip_configuration_name         = optional(string, "primary")
-    create_public_ip              = optional(bool, false)
-    public_ip_name                = optional(string)
-    public_ip_resource_group_name = optional(string)
-    public_ip_id                  = optional(string)
-    private_ip_address            = optional(string)
-    lb_backend_pool_id            = optional(string)
-    attach_to_lb_backend_pool     = optional(bool, false)
-    appgw_backend_pool_id         = optional(string)
-    attach_to_appgw_backend_pool  = optional(bool, false)
+    name      = string
+    subnet_id = string
+    ip_configurations = map(object({
+      name                          = optional(string, "primary")
+      create_public_ip              = optional(bool, false)
+      public_ip_name                = optional(string)
+      public_ip_resource_group_name = optional(string)
+      primary                       = optional(bool, true)
+      public_ip_id                  = optional(string)
+      private_ip_address            = optional(string)
+    }))
+    lb_backend_pool_id           = optional(string)
+    attach_to_lb_backend_pool    = optional(bool, false)
+    appgw_backend_pool_id        = optional(string)
+    attach_to_appgw_backend_pool = optional(bool, false)
   }))
   validation { # create_public_ip, public_ip_name
-    condition = alltrue([
-      for v in var.interfaces : v.public_ip_name != null if v.create_public_ip
-    ])
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        for config_key, config in interface.ip_configurations :
+        config.public_ip_name != null if config.create_public_ip
+      ]
+    ]))
     error_message = <<-EOF
     The `public_ip_name` property is required when `create_public_ip` is set to `true`.
     EOF
   }
   validation { # public_ip_id, create_public_ip, public_ip_name
-    condition = alltrue([
-      for v in var.interfaces : v.create_public_ip == false && v.public_ip_name == null if v.public_ip_id != null
-    ])
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        for config_key, config in interface.ip_configurations :
+        config.create_public_ip == false && config.public_ip_name == null if config.public_ip_id != null
+      ]
+    ]))
     error_message = <<-EOF
     When using `public_ip_id` property, `create_public_ip` must be set to `false` and `public_ip_name` must not be set.
+    EOF
+  }
+  validation { # primary_ip
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        length([
+          for config_key, config in interface.ip_configurations : config_key
+          if config.primary == true
+        ]) == 1
+      ]
+    ]))
+    error_message = <<-EOF
+    Each interface must have exactly one IP configuration with `primary = true`.
     EOF
   }
   validation { # lb_backend_pool_id & attach_to_lb_backend_pool

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -270,22 +270,25 @@ Following configuration options are available:
 
 - `name`                           - (`string`, required) the interface name.
 - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
-- `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-- `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
-                                     Name Label for each Virtual Machine Instance.
-- `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
-                                     IP Address, possible values are in the range from 4 to 32.
-- `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
-                                     Addresses should be allocated.
-- `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                     existing Public IP Prefix resource.
-- `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
-                                     properties above (name and resource group), in case you want to avoid using a data source
-                                     block.
+- `ip_configurations`              - (`map`, required) A map that contains the IP configurations for the interface.
+  - `name`                           - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+  - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+  - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                       Name Label for each Virtual Machine Instance.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                      IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                       Addresses should be allocated.
+  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                       existing Public IP Prefix resource.
+  - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
+                                       properties above (name and resource group), in case you want to avoid using a data source
+                                       block.
 - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
-                                     backend pools to associate the interface with.
+                                     backend pools to associate the interface with. Only applied to primary IP configuration.
 - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
-                                     pools to associate the interface with.
+                                     pools to associate the interface with. Only applied to primary IP configuration.
 
 Example:
 
@@ -294,16 +297,33 @@ Example:
   {
     name       = "management"
     subnet_id  = azurerm_subnet.my_mgmt_subnet.id
-    create_pip = true
+    ip_configurations = {
+        primary-ip = {
+          name             = "primary-ip"
+          primary          = true
+          create_public_ip = true
+    }
   },
   {
     name      = "private"
     subnet_id = azurerm_subnet.my_priv_subnet.id
+    ip_configurations = {
+        primary-ip = {
+          name             = "primary-ip"
+          primary          = true
+          create_public_ip = false
+    }
   },
   {
     name                = "public"
     subnet_id           = azurerm_subnet.my_pub_subnet.id
     lb_backend_pool_ids = [azurerm_lb_backend_address_pool.lb_backend.id]
+    ip_configurations = {
+        primary-ip = {
+          name             = "primary-ip"
+          primary          = true
+          create_public_ip = true
+    }
   }
 ]
 ```
@@ -313,16 +333,20 @@ Type:
 
 ```hcl
 list(object({
-    name                           = string
-    subnet_id                      = string
-    create_public_ip               = optional(bool, false)
-    pip_domain_name_label          = optional(string)
-    pip_idle_timeout_in_minutes    = optional(number)
-    pip_prefix_name                = optional(string)
-    pip_prefix_resource_group_name = optional(string)
-    pip_prefix_id                  = optional(string)
-    lb_backend_pool_ids            = optional(list(string), [])
-    appgw_backend_pool_ids         = optional(list(string), [])
+    name      = string
+    subnet_id = string
+    ip_configurations = map(object({
+      name                           = optional(string, "primary")
+      primary                        = optional(bool, true)
+      create_public_ip               = optional(bool, false)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
+    }))
+    lb_backend_pool_ids    = optional(list(string), [])
+    appgw_backend_pool_ids = optional(list(string), [])
   }))
 ```
 

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -272,19 +272,20 @@ Following configuration options are available:
 - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
 - `ip_configurations`              - (`map`, required) A map that contains the IP configurations for the interface.
   - `name`                           - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+  - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary
+                                       one.
   - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-  - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
   - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
                                        Name Label for each Virtual Machine Instance.
-  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
-                                      IP Address, possible values are in the range from 4 to 32.
-  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
-                                       Addresses should be allocated.
+  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the 
+                                       Public IP Address, possible values are in the range from 4 to 32.
+  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public
+                                       IP Addresses should be allocated.
   - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
                                        existing Public IP Prefix resource.
   - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
-                                       properties above (name and resource group), in case you want to avoid using a data source
-                                       block.
+                                       properties above (name and resource group), in case you want to avoid using a data
+                                       source block.
 - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
                                      backend pools to associate the interface with. Only applied to primary IP configuration.
 - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -4,7 +4,17 @@ locals {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip_prefix
 data "azurerm_public_ip_prefix" "allocate" {
-  for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
+  # for_each = { for v in var.interfaces : v.name => v if v.pip_prefix_name != null }
+  for_each = {
+    for item in flatten([
+      for v in var.interfaces : [
+        for ip_key, ip_value in v.ip_configurations : {
+          key   = "${v.name}-${ip_key}"
+          value = ip_value
+        } if ip_value.pip_prefix_name != null
+      ]
+    ]) : item.key => item.value
+  }
 
   name                = each.value.pip_prefix_name
   resource_group_name = coalesce(each.value.pip_prefix_resource_group_name, var.resource_group_name)
@@ -87,23 +97,22 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
       enable_ip_forwarding          = nic.key == 0 ? false : true
       enable_accelerated_networking = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
 
-      ip_configuration {
-        name                                         = "primary"
-        primary                                      = true
-        subnet_id                                    = nic.value.subnet_id
-        load_balancer_backend_address_pool_ids       = nic.value.lb_backend_pool_ids
-        application_gateway_backend_address_pool_ids = nic.value.appgw_backend_pool_ids
+      dynamic "ip_configuration" {
+        for_each = nic.value.ip_configurations
 
-        dynamic "public_ip_address" {
-          for_each = nic.value.create_public_ip ? [1] : []
-          iterator = pip
+        content {
+          name                                         = ip_configuration.value.name
+          primary                                      = ip_configuration.value.primary
+          subnet_id                                    = nic.value.subnet_id
+          load_balancer_backend_address_pool_ids       = ip_configuration.value.primary == true ? nic.value.lb_backend_pool_ids : null
+          application_gateway_backend_address_pool_ids = ip_configuration.value.primary == true ? nic.value.appgw_backend_pool_ids : null
 
-          content {
-            name                    = nic.value.name
-            domain_name_label       = nic.value.pip_domain_name_label
-            idle_timeout_in_minutes = nic.value.pip_idle_timeout_in_minutes
+          public_ip_address {
+            name                    = ip_configuration.value.name
+            domain_name_label       = ip_configuration.value.pip_domain_name_label
+            idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
             public_ip_prefix_id = try(
-              nic.value.pip_prefix_id, data.azurerm_public_ip_prefix.allocate[nic.value.name].id, null
+              ip_configuration.value.pip_prefix_id, data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id, null
             )
           }
         }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -229,22 +229,25 @@ variable "interfaces" {
 
   - `name`                           - (`string`, required) the interface name.
   - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
-  - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-  - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
-                                       Name Label for each Virtual Machine Instance.
-  - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
-                                       IP Address, possible values are in the range from 4 to 32.
-  - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
-                                       Addresses should be allocated.
-  - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
-                                       existing Public IP Prefix resource.
-  - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
-                                       properties above (name and resource group), in case you want to avoid using a data source
-                                       block.
+  - `ip_configurations`              - (`map`, required) A map that contains the IP configurations for the interface.
+    - `name`                           - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
+    - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
+    - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
+                                         Name Label for each Virtual Machine Instance.
+    - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
+                                        IP Address, possible values are in the range from 4 to 32.
+    - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
+                                         Addresses should be allocated.
+    - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
+                                         existing Public IP Prefix resource.
+    - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
+                                         properties above (name and resource group), in case you want to avoid using a data source
+                                         block.
   - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
-                                       backend pools to associate the interface with.
+                                       backend pools to associate the interface with. Only applied to primary IP configuration.
   - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend
-                                       pools to associate the interface with.
+                                       pools to associate the interface with. Only applied to primary IP configuration.
 
   Example:
 
@@ -253,31 +256,52 @@ variable "interfaces" {
     {
       name       = "management"
       subnet_id  = azurerm_subnet.my_mgmt_subnet.id
-      create_pip = true
+      ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = true
+      }
     },
     {
       name      = "private"
       subnet_id = azurerm_subnet.my_priv_subnet.id
+      ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = false
+      }
     },
     {
       name                = "public"
       subnet_id           = azurerm_subnet.my_pub_subnet.id
       lb_backend_pool_ids = [azurerm_lb_backend_address_pool.lb_backend.id]
+      ip_configurations = {
+          primary-ip = {
+            name             = "primary-ip"
+            primary          = true
+            create_public_ip = true
+      }
     }
   ]
   ```
   EOF
   type = list(object({
-    name                           = string
-    subnet_id                      = string
-    create_public_ip               = optional(bool, false)
-    pip_domain_name_label          = optional(string)
-    pip_idle_timeout_in_minutes    = optional(number)
-    pip_prefix_name                = optional(string)
-    pip_prefix_resource_group_name = optional(string)
-    pip_prefix_id                  = optional(string)
-    lb_backend_pool_ids            = optional(list(string), [])
-    appgw_backend_pool_ids         = optional(list(string), [])
+    name      = string
+    subnet_id = string
+    ip_configurations = map(object({
+      name                           = optional(string, "primary")
+      primary                        = optional(bool, true)
+      create_public_ip               = optional(bool, false)
+      pip_domain_name_label          = optional(string)
+      pip_idle_timeout_in_minutes    = optional(number)
+      pip_prefix_name                = optional(string)
+      pip_prefix_resource_group_name = optional(string)
+      pip_prefix_id                  = optional(string)
+    }))
+    lb_backend_pool_ids    = optional(list(string), [])
+    appgw_backend_pool_ids = optional(list(string), [])
   }))
   validation { # lb_backend_pool_ids & appgw_backend_pool_ids
     condition     = length(var.interfaces[0].lb_backend_pool_ids) == 0 && length(var.interfaces[0].appgw_backend_pool_ids) == 0
@@ -285,10 +309,27 @@ variable "interfaces" {
     The `lb_backend_pool_ids` and `appgw_backend_pool_ids` properties are not acceptable for the 1st (management) interface.
     EOF
   }
+  validation { # primary_ip
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        length([
+          for config_key, config in interface.ip_configurations : config_key
+          if config.primary == true
+        ]) == 1
+      ]
+    ]))
+    error_message = <<-EOF
+    Each interface must have exactly one IP configuration with `primary = true`.
+    EOF
+  }
   validation { # pip_idle_timeout_in_minutes
-    condition = alltrue([
-      for v in var.interfaces : (v.pip_idle_timeout_in_minutes >= 4 && v.pip_idle_timeout_in_minutes <= 32)
-    if v.pip_idle_timeout_in_minutes != null])
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        for ip_config_name, ip_config in coalesce(interface.ip_configurations, {}) :
+        (ip_config.pip_idle_timeout_in_minutes >= 4 && ip_config.pip_idle_timeout_in_minutes <= 32)
+        if ip_config.pip_idle_timeout_in_minutes != null
+      ]
+    ]))
     error_message = <<-EOF
     The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -231,19 +231,20 @@ variable "interfaces" {
   - `subnet_id`                      - (`string`, required) ID of an existing subnet to create the interface in.
   - `ip_configurations`              - (`map`, required) A map that contains the IP configurations for the interface.
     - `name`                           - (`string`, optional, defaults to `primary`) the name of the interface IP configuration.
+    - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary
+                                         one.
     - `create_public_ip`               - (`bool`, optional, defaults to `false`) if `true`, create a public IP for the interface.
-    - `primary`                        - (`bool`, optional, defaults to `true`) sets the current IP configuration as the primary one.
     - `pip_domain_name_label`          - (`string`, optional, defaults to `null`) the Prefix which should be used for the Domain
                                          Name Label for each Virtual Machine Instance.
-    - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the Public
-                                        IP Address, possible values are in the range from 4 to 32.
-    - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public IP
-                                         Addresses should be allocated.
+    - `pip_idle_timeout_in_minutes`    - (`number`, optional, defaults to Azure default) the Idle Timeout in minutes for the 
+                                         Public IP Address, possible values are in the range from 4 to 32.
+    - `pip_prefix_name`                - (`string`, optional) the name of an existing Public IP Address Prefix from where Public
+                                         IP Addresses should be allocated.
     - `pip_prefix_resource_group_name` - (`string`, optional, defaults to the VMSS's RG) name of a Resource Group hosting an 
                                          existing Public IP Prefix resource.
     - `pip_prefix_id`                  - (`string`, optional) you can specify Public IP Prefix ID as an alternative to the
-                                         properties above (name and resource group), in case you want to avoid using a data source
-                                         block.
+                                         properties above (name and resource group), in case you want to avoid using a data
+                                         source block.
   - `lb_backend_pool_ids`            - (`list`, optional, defaults to `[]`) a list of identifiers of existing Load Balancer
                                        backend pools to associate the interface with. Only applied to primary IP configuration.
   - `appgw_backend_pool_ids`         - (`list`, optional, defaults to `[]`) a list of identifier of Application Gateway's backend


### PR DESCRIPTION
## Description

- PR adds capability to add secondary IP address to VMSeries interfaces
- Transformed the static `ip_configurations` object from `azurerm_network_interface` resource into a `dynamic` block
- `azurerm_public_ip` resource and data source now iterate over each `ip_configurations` for each interface
- Updated outputs from the module to grab public IPs for every secondary IP (if `create_public_ip` is set to `true`)
- Added new variable validation that verified that only one of the interfaces is set to `primary` 
- Updates associated examples
- Updated variables docstrings

## Motivation and Context

- No possibility to add secondary IP addresses which are sometimes required for different configurations

## How Has This Been Tested?

- Local testing + ChatOps

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
