### PR TITLE
docs: Publish Cloud NGFW Assets to SWFW Hub fix

### DIFF
--- a/examples/cloudngfw_centralized_single_vwan/.header.md
+++ b/examples/cloudngfw_centralized_single_vwan/.header.md
@@ -1,7 +1,7 @@
 ---
 short_title: Cloud NGFW Single Virtual WAN
 type: refarch
-show_in_hub: false
+show_in_hub: true
 swfw: cloudngfw
 ---
 # Reference Architecture with Terraform: Cloud NGFW in Azure, Virtual WAN Design Model.

--- a/examples/cloudngfw_centralized_vnet/.header.md
+++ b/examples/cloudngfw_centralized_vnet/.header.md
@@ -1,7 +1,7 @@
 ---
 short_title: Cloud NGFW Centralized VNet
 type: refarch
-show_in_hub: false
+show_in_hub: true
 swfw: cloudngfw
 ---
 # Reference Architecture with Terraform: Cloud NGFW in Azure, Virtual Network Design Model.

--- a/examples/cloudngfw_distributed/.header.md
+++ b/examples/cloudngfw_distributed/.header.md
@@ -1,7 +1,7 @@
 ---
 short_title: CloudNGFW Distributed
 type: refarch
-show_in_hub: false
+show_in_hub: true
 swfw: cloudngfw
 ---
 # Reference Architecture with Terraform: Cloud NGFW in Azure, Distributed Design Model.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This updates the `header.md` files in CloudNGFW examples and changes the `show_in_hub` to `true` in heredocs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Migara changed the READMEs but didn't update the headers, which breaks the pipeline.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
