### PR TITLE
fix(vmss): Public IP configuration naming issue in Flexible mode

### DIFF
--- a/examples/vmseries_transit_vnet_common_autoscale/.header.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/.header.md
@@ -129,6 +129,12 @@ A non-platform requirement would be a running Panorama instance. For full automa
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for the scale set [`common`](./example.tfvars#L224).
+- _(optional)_ if you want to switch Virtual Machine Scale Set (VMSS) from `Uniform` (default) to `Flexible` mode, add the 
+  following properties under `virtual_machine_scale_set` map in the `terraform.tfvars` file:
+  ```hcl
+  orchestration_type          = "Flexible"
+  platform_fault_domain_count = 1
+  ```
 - _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
 - provide `subscription_id` either by creating an environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value
   in your shell (recommended option) or by setting the value of `subscription_id` variable within your `tfvars` file (discouraged

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -129,6 +129,12 @@ A non-platform requirement would be a running Panorama instance. For full automa
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
   might want to also adjust the `bootstrap_options` for the scale set [`common`](./example.tfvars#L224).
+- _(optional)_ if you want to switch Virtual Machine Scale Set (VMSS) from `Uniform` (default) to `Flexible` mode, add the
+  following properties under `virtual_machine_scale_set` map in the `terraform.tfvars` file:
+  ```hcl
+  orchestration_type          = "Flexible"
+  platform_fault_domain_count = 1
+  ```
 - _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
 - provide `subscription_id` either by creating an environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value
   in your shell (recommended option) or by setting the value of `subscription_id` variable within your `tfvars` file (discouraged

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/.header.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/.header.md
@@ -121,8 +121,14 @@ requirements:
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
-  might want to also adjust the `bootstrap_options` for each scale set ([inbound](./example.tfvars#L205) and
-  [obew](./example.tfvars#L249) separately).
+  might want to also adjust the `bootstrap_options` for each scale set (`inbound` and `obew`) separately.
+- _(optional)_ if you want to switch Virtual Machine Scale Set (VMSS) from `Uniform` (default) to `Flexible` mode, add the 
+  following properties under `virtual_machine_scale_set` map for each scale set (`inbound` and `obew`) separately in the 
+  `terraform.tfvars` file:
+  ```hcl
+  orchestration_type          = "Flexible"
+  platform_fault_domain_count = 1
+  ```
 - _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
 - provide `subscription_id` either by creating an environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value
   in your shell (recommended option) or by setting the value of `subscription_id` variable within your `tfvars` file (discouraged

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -121,8 +121,14 @@ requirements:
 - checkout the code locally (if you haven't done so yet)
 - copy the [`example.tfvars`](./example.tfvars) file, rename it to `terraform.tfvars` and adjust it to your needs (take a closer
   look at the `TODO` markers). If you already have a configured Panorama (with at least minimum configuration described above) you
-  might want to also adjust the `bootstrap_options` for each scale set ([inbound](./example.tfvars#L205) and
-  [obew](./example.tfvars#L249) separately).
+  might want to also adjust the `bootstrap_options` for each scale set (`inbound` and `obew`) separately.
+- _(optional)_ if you want to switch Virtual Machine Scale Set (VMSS) from `Uniform` (default) to `Flexible` mode, add the
+  following properties under `virtual_machine_scale_set` map for each scale set (`inbound` and `obew`) separately in the
+  `terraform.tfvars` file:
+  ```hcl
+  orchestration_type          = "Flexible"
+  platform_fault_domain_count = 1
+  ```
 - _(optional)_ authenticate to AzureRM, switch to the Subscription of your choice
 - provide `subscription_id` either by creating an environment variable named `ARM_SUBSCRIPTION_ID` with Subscription ID as value
   in your shell (recommended option) or by setting the value of `subscription_id` variable within your `tfvars` file (discouraged

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -93,7 +93,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
     iterator = nic
 
     content {
-      name                          = "${nic.value.name}-${nic.key}"
+      name                          = nic.value.name
       primary                       = nic.key == 0 ? true : false
       enable_ip_forwarding          = nic.key == 0 ? false : true
       enable_accelerated_networking = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
@@ -102,7 +102,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
         for_each = nic.value.ip_configurations
 
         content {
-          name      = "${ip_configuration.value.name}-${ip_configuration.key}"
+          name      = ip_configuration.value.name
           primary   = ip_configuration.value.primary
           subnet_id = nic.value.subnet_id
           load_balancer_backend_address_pool_ids = ip_configuration.value.primary == true ? (
@@ -113,7 +113,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
           ) : null
 
           public_ip_address {
-            name                    = "${ip_configuration.value.name}-${ip_configuration.key}"
+            name                    = "${nic.value.name}-${ip_configuration.value.name}"
             domain_name_label       = ip_configuration.value.pip_domain_name_label
             idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
             public_ip_prefix_id = try(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes Public IP configuration naming issue when running `vmss` module in `Flexible` orchestration type.

It also adds some docs to VMSS-based examples how to switch VMSS to Flexible mode.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

VMSS in Flexible mode failed to deploy.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
