### PR TITLE
fix(vmss): Public IP creation flag in vmss module

### DIFF
--- a/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
@@ -337,7 +337,7 @@ scale_sets = {
     }
     interfaces = [
       {
-        name       = "management"
+        name       = "common-vmss-mgmt"
         subnet_key = "management"
         ip_configurations = {
           primary-ip = {
@@ -348,7 +348,7 @@ scale_sets = {
         }
       },
       {
-        name                    = "public"
+        name                    = "common-vmss-public"
         subnet_key              = "public"
         load_balancer_key       = "public"
         application_gateway_key = "public"
@@ -361,7 +361,7 @@ scale_sets = {
         }
       },
       {
-        name              = "private"
+        name              = "common-vmss-private"
         subnet_key        = "private"
         load_balancer_key = "private"
         ip_configurations = {

--- a/examples/vmseries_transit_vnet_common_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/main.tf
@@ -422,7 +422,7 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name      = v.name
+      name      = "${var.name_prefix}${v.name}"
       subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
       ip_configurations = { for vk, vv in v.ip_configurations : vk => {
         name                           = vv.name

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
@@ -281,7 +281,7 @@ scale_sets = {
     }
     interfaces = [
       {
-        name       = "management"
+        name       = "inbound-vmss-mgmt"
         subnet_key = "management"
         ip_configurations = {
           primary-ip = {
@@ -292,7 +292,7 @@ scale_sets = {
         }
       },
       {
-        name              = "public"
+        name              = "inbound-vmss-public"
         subnet_key        = "public"
         load_balancer_key = "public"
         ip_configurations = {
@@ -304,7 +304,7 @@ scale_sets = {
         }
       },
       {
-        name       = "private"
+        name       = "inbound-vmss-private"
         subnet_key = "private"
         ip_configurations = {
           primary-ip = {
@@ -371,7 +371,7 @@ scale_sets = {
     }
     interfaces = [
       {
-        name       = "management"
+        name       = "obew-vmss-mgmt"
         subnet_key = "management"
         ip_configurations = {
           primary-ip = {
@@ -382,7 +382,7 @@ scale_sets = {
         }
       },
       {
-        name       = "public"
+        name       = "obew-vmss-public"
         subnet_key = "public"
         ip_configurations = {
           primary-ip = {
@@ -393,7 +393,7 @@ scale_sets = {
         }
       },
       {
-        name              = "private"
+        name              = "obew-vmss-private"
         subnet_key        = "private"
         load_balancer_key = "private"
         ip_configurations = {

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
@@ -422,7 +422,7 @@ module "vmss" {
 
   interfaces = [
     for v in each.value.interfaces : {
-      name      = v.name
+      name      = "${var.name_prefix}${v.name}"
       subnet_id = module.vnet[each.value.vnet_key].subnet_ids[v.subnet_key]
       ip_configurations = { for vk, vv in v.ip_configurations : vk => {
         name                           = vv.name

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -112,15 +112,18 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
             nic.value.appgw_backend_pool_ids
           ) : null
 
-          public_ip_address {
-            name                    = "${nic.value.name}-${ip_configuration.value.name}"
-            domain_name_label       = ip_configuration.value.pip_domain_name_label
-            idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
-            public_ip_prefix_id = try(
-              ip_configuration.value.pip_prefix_id,
-              data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
-              null
-            )
+          dynamic "public_ip_address" {
+            for_each = ip_configuration.value.create_public_ip ? [1] : []
+            content {
+              name                    = "${nic.value.name}-${ip_configuration.value.name}-pip"
+              domain_name_label       = ip_configuration.value.pip_domain_name_label
+              idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
+              public_ip_prefix_id = try(
+                ip_configuration.value.pip_prefix_id,
+                data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
+                null
+              )
+            }
           }
         }
       }
@@ -235,15 +238,18 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
             nic.value.appgw_backend_pool_ids
           ) : null
 
-          public_ip_address {
-            name                    = ip_configuration.value.name
-            domain_name_label       = ip_configuration.value.pip_domain_name_label
-            idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
-            public_ip_prefix_id = try(
-              ip_configuration.value.pip_prefix_id,
-              data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
-              null
-            )
+          dynamic "public_ip_address" {
+            for_each = ip_configuration.value.create_public_ip ? [1] : []
+            content {
+              name                    = "${nic.value.name}-${ip_configuration.value.name}-pip"
+              domain_name_label       = ip_configuration.value.pip_domain_name_label
+              idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
+              public_ip_prefix_id = try(
+                ip_configuration.value.pip_prefix_id,
+                data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
+                null
+              )
+            }
           }
         }
       }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes Public IP resources creation controlled by `create_public_ip` property in `vmss` module.
It also introduces some cosmetic changes to resource naming.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `create_public_ip` flag had no impact and Public IPs were always created even when set to `false`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally (both Uniform & Flexible VMSS modes).

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
