### PR TITLE
fix(virtual_network_gateway): Remove public IP association from ExpressRoute VNG

### DIFF
--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -465,24 +465,29 @@ object({
 #### ip_configurations
 
 A map defining the Public IPs used by the Virtual Network Gateway.
-  
+
 Following properties are available:
 - `primary`   - (`map`, required) a map defining the primary Public IP address, following properties are available:
   - `name`                           - (`string`, required) name of the IP config.
   - `create_public_ip`               - (`bool`, optional, defaults to `true`) controls if a Public IP is created or sourced.
+                                       Must be set to `false` for `ExpressRoute` type gateways.
   - `public_ip_name`                 - (`string`, optional) name of a Public IP resource, required unless `public_ip` module
                                        and `public_ip_id` property are used. Depending on the value of `create_public_ip`
                                        property, this will be a name of a newly created or existing resource (for values of
-                                       `true` and `false` accordingly).
+                                       `true` and `false` accordingly). Must be `null` for `ExpressRoute` type gateways.
   - `public_ip_resource_group_name`  - (`string`, optional, defaults to the Load Balancer's RG) name of a Resource Group
-                                       hosting an existing Public IP resource.
+                                       hosting an existing Public IP resource. Must be `null` for `ExpressRoute` type gateways.
   - `public_ip_id`                   - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
                                        interface. Property is used when public IP is not created or sourced within this module.
+                                       Must be `null` for `ExpressRoute` type gateways.
   - `dynamic_private_ip_allocation`  - (`bool`, optional, defaults to `true`) controls if the private IP address is assigned
                                        dynamically or statically.
 - `secondary` - (`map`, optional, defaults to `null`) a map defining the secondary Public IP address resource. Required only
                 for `type` set to `Vpn` and `active-active` set to `true`. Same properties available as for `primary` property.
 
+**Note!** \
+For `instance_settings.type` set to `ExpressRoute`, Public IPs are created automatically and fully managed by Azure platform. 
+In that case, `create_public_ip` must be set to `false`, and both `public_ip_name` and `public_ip_id` must be `null`.
 
 
 Type: 

--- a/modules/virtual_network_gateway/main.tf
+++ b/modules/virtual_network_gateway/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_virtual_network_gateway" "this" {
 
     content {
       name = ip_configuration.value.name
-      public_ip_address_id = coalesce(
+      public_ip_address_id = var.instance_settings.type == "ExpressRoute" ? null : coalesce(
         ip_configuration.value.public_ip_id,
         try(azurerm_public_ip.this[ip_configuration.value.name].id, data.azurerm_public_ip.this[ip_configuration.value.name].id, null)
       )
@@ -125,6 +125,30 @@ resource "azurerm_virtual_network_gateway" "this" {
   tags = var.tags
 
   lifecycle {
+    precondition { # public_ip_id & public_ip_name
+      condition = var.instance_settings.type == "ExpressRoute" ? true : alltrue([
+        (var.ip_configurations.primary.public_ip_name != null || var.ip_configurations.primary.public_ip_id != null),
+        (
+          var.ip_configurations.secondary != null ? (
+            var.ip_configurations.secondary.public_ip_name != null || var.ip_configurations.secondary.public_ip_id != null
+          ) : true
+        )
+      ])
+      error_message = <<-EOF
+      VNG Name: [${var.name}]
+      Either `public_ip_name` or `public_ip_id` property must be set.
+      EOF
+    }
+    precondition { # ip_configurations.secondary
+      condition = var.instance_settings.active_active ? (
+        var.ip_configurations.secondary != null
+      ) : var.ip_configurations.secondary == null
+      error_message = <<-EOF
+      VNG Name: [${var.name}]
+      The `ip_configurations.secondary` property is required ONLY when `instance_settings.active_active` property is set
+      to `true`.
+      EOF
+    }
     precondition { # bgp
       condition     = var.instance_settings.type == "ExpressRoute" ? var.bgp == null : true
       error_message = <<-EOF
@@ -138,16 +162,6 @@ resource "azurerm_virtual_network_gateway" "this" {
       VNG Name: [${var.name}]
       BGP configuration is supported only for Virtual Network Gateways of "VPN" type, `var.azure_bgp_peer_addresses` map should
       be empty.
-      EOF
-    }
-    precondition { # ip_configurations.secondary
-      condition = var.instance_settings.active_active ? (
-        var.ip_configurations.secondary != null
-      ) : var.ip_configurations.secondary == null
-      error_message = <<-EOF
-      VNG Name: [${var.name}]
-      The `ip_configurations.secondary` property is required ONLY when `instance_settings.active_active` property is set
-      to `true`.
       EOF
     }
     precondition { # bgp.configuration.secondary_peering_addresses

--- a/modules/virtual_network_gateway/variables.tf
+++ b/modules/virtual_network_gateway/variables.tf
@@ -167,24 +167,29 @@ variable "instance_settings" {
 variable "ip_configurations" {
   description = <<-EOF
   A map defining the Public IPs used by the Virtual Network Gateway.
-  
+
   Following properties are available:
   - `primary`   - (`map`, required) a map defining the primary Public IP address, following properties are available:
     - `name`                           - (`string`, required) name of the IP config.
     - `create_public_ip`               - (`bool`, optional, defaults to `true`) controls if a Public IP is created or sourced.
+                                         Must be set to `false` for `ExpressRoute` type gateways.
     - `public_ip_name`                 - (`string`, optional) name of a Public IP resource, required unless `public_ip` module
                                          and `public_ip_id` property are used. Depending on the value of `create_public_ip`
                                          property, this will be a name of a newly created or existing resource (for values of
-                                         `true` and `false` accordingly).
+                                         `true` and `false` accordingly). Must be `null` for `ExpressRoute` type gateways.
     - `public_ip_resource_group_name`  - (`string`, optional, defaults to the Load Balancer's RG) name of a Resource Group
-                                         hosting an existing Public IP resource.
+                                         hosting an existing Public IP resource. Must be `null` for `ExpressRoute` type gateways.
     - `public_ip_id`                   - (`string`, optional, defaults to `null`) ID of the public IP to associate with the
                                          interface. Property is used when public IP is not created or sourced within this module.
+                                         Must be `null` for `ExpressRoute` type gateways.
     - `dynamic_private_ip_allocation`  - (`bool`, optional, defaults to `true`) controls if the private IP address is assigned
                                          dynamically or statically.
   - `secondary` - (`map`, optional, defaults to `null`) a map defining the secondary Public IP address resource. Required only
                   for `type` set to `Vpn` and `active-active` set to `true`. Same properties available as for `primary` property.
 
+  **Note!** \
+  For `instance_settings.type` set to `ExpressRoute`, Public IPs are created automatically and fully managed by Azure platform. 
+  In that case, `create_public_ip` must be set to `false`, and both `public_ip_name` and `public_ip_id` must be `null`.
   EOF
   type = object({
     primary = object({
@@ -209,19 +214,6 @@ variable "ip_configurations" {
     ) : true
     error_message = <<-EOF
     The `name` property has to be unique among all IP configurations.
-    EOF
-  }
-  validation { # public_ip_id, public_ip_name
-    condition = alltrue([
-      (var.ip_configurations.primary.public_ip_name != null || var.ip_configurations.primary.public_ip_id != null),
-      (
-        var.ip_configurations.secondary != null ? (
-          var.ip_configurations.secondary.public_ip_name != null || var.ip_configurations.secondary.public_ip_id != null
-        ) : true
-      )
-    ])
-    error_message = <<-EOF
-    Either `public_ip_name` or `public_ip_id` property must be set.
     EOF
   }
   validation { # public_ip_id, create_public_ip, public_ip_name

--- a/tests/virtual_network_gateway/example.tfvars
+++ b/tests/virtual_network_gateway/example.tfvars
@@ -80,8 +80,7 @@ virtual_network_gateways = {
     ip_configurations = {
       primary = {
         name             = "primary"
-        create_public_ip = true
-        public_ip_name   = "expressroute_pip"
+        create_public_ip = false
       }
     }
   }
@@ -99,8 +98,7 @@ virtual_network_gateways = {
     ip_configurations = {
       primary = {
         name             = "primary"
-        create_public_ip = true
-        public_ip_name   = "er_policy_pip"
+        create_public_ip = false
       }
     }
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR fixes a bug in `virtual_network_gateway` module concerning ExpressRoute VNGs and Public IP resource association. For ExpressRoute, the module now sets Public IP to `null` and doesn't require creating or sourcing one from validation standpoint.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ExpressRoute-type VNG failed to create due to disallowed Public IP association, which is now automatically created and fully managed by Azure platform.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
