### PR TITLE
feat(virtual_network_gateway): Remove deprecated VNG SKUs support from the module

### DIFF
--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -414,19 +414,14 @@ table below for details on available combinations:
   <tr><td>ErGw3AZ</td></tr>
   <tr>
     <td rowspan="11">Vpn</td>
-    <td rowspan="3">Generation1</td>
+    <td rowspan="2">Generation1</td>
     <td>Basic</td>
   </tr>
-  <tr><td>VpnGw1</td></tr>
   <tr><td>VpnGw1AZ</td></tr>
   <tr>
-    <td rowspan="8">Generation1/Generation2</td>
-    <td>VpnGw2</td>
+    <td rowspan="4">Generation1/Generation2</td>
+    <td>VpnGw2AZ</td>
   </tr>
-  <tr><td>VpnGw3</td></tr>
-  <tr><td>VpnGw4</td></tr>
-  <tr><td>VpnGw5</td></tr>
-  <tr><td>VpnGw2AZ</td></tr>
   <tr><td>VpnGw3AZ</td></tr>
   <tr><td>VpnGw4AZ</td></tr>
   <tr><td>VpnGw5AZ</td></tr>

--- a/modules/virtual_network_gateway/variables.tf
+++ b/modules/virtual_network_gateway/variables.tf
@@ -76,19 +76,14 @@ variable "instance_settings" {
     <tr><td>ErGw3AZ</td></tr>
     <tr>
       <td rowspan="11">Vpn</td>
-      <td rowspan="3">Generation1</td>
+      <td rowspan="2">Generation1</td>
       <td>Basic</td>
     </tr>
-    <tr><td>VpnGw1</td></tr>
     <tr><td>VpnGw1AZ</td></tr>
     <tr>
-      <td rowspan="8">Generation1/Generation2</td>
-      <td>VpnGw2</td>
+      <td rowspan="4">Generation1/Generation2</td>
+      <td>VpnGw2AZ</td>
     </tr>
-    <tr><td>VpnGw3</td></tr>
-    <tr><td>VpnGw4</td></tr>
-    <tr><td>VpnGw5</td></tr>
-    <tr><td>VpnGw2AZ</td></tr>
     <tr><td>VpnGw3AZ</td></tr>
     <tr><td>VpnGw4AZ</td></tr>
     <tr><td>VpnGw5AZ</td></tr>
@@ -145,7 +140,7 @@ variable "instance_settings" {
   }
   validation { # type & sku
     condition = (var.instance_settings.type == "Vpn" && contains(
-      ["Basic", "VpnGw1", "VpnGw2", "VpnGw3", "VpnGw4", "VpnGw5", "VpnGw1AZ", "VpnGw2AZ", "VpnGw3AZ", "VpnGw4AZ", "VpnGw5AZ"],
+      ["Basic", "VpnGw1AZ", "VpnGw2AZ", "VpnGw3AZ", "VpnGw4AZ", "VpnGw5AZ"],
       var.instance_settings.sku
       )) || (
       var.instance_settings.type == "ExpressRoute" && contains(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR removes deprecated VPN-type Virtual Network Gateway SKUs from the list of supported SKUs within the `virtual_network_gateway` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[VpnGw1-5 SKUs will be retired Sept. 2026](https://azure.microsoft.com/en-us/updates?id=vpngw1-5-non-az-skus-will-be-retired-on-30-september-2026)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked manually.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
