### PR TITLE
feat(vmseries): Introduce data disks to vmseries module

### DIFF
--- a/examples/panorama_standalone/main.tf
+++ b/examples/panorama_standalone/main.tf
@@ -142,8 +142,7 @@ module "panorama" {
     private_ip_address            = v.private_ip_address
   }]
 
-  logging_disks = { for k, v in each.value.logging_disks :
-  k => merge(v, { name = "${var.name_prefix}${coalesce(v.name, "${each.value.name}-osdisk")}" }) }
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
 
   tags       = var.tags
   depends_on = [module.vnet]

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -849,7 +849,15 @@ The most basic properties are as follows:
   - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                 the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-  For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+- `logging_disks`   - (`map`, optional, defaults to `null`) configuration of additional data disks for VM-Series logs. Most
+                      common properties are:
+
+  - `name` - (`string`, required) the Managed Disk name.
+  - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
 
 
 Type: 
@@ -944,6 +952,12 @@ map(object({
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
 ```
 

--- a/examples/vmseries_gwlb/main.tf
+++ b/examples/vmseries_gwlb/main.tf
@@ -342,6 +342,8 @@ module "vmseries" {
     appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
+
   tags = var.tags
   depends_on = [
     module.vnet,

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -597,7 +597,15 @@ variable "vmseries" {
     - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                   the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-    For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+  - `logging_disks`   - (`map`, optional, defaults to `null`) configuration of additional data disks for VM-Series logs. Most
+                        common properties are:
+
+    - `name` - (`string`, required) the Managed Disk name.
+    - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
   EOF
   default     = {}
   nullable    = false
@@ -690,6 +698,12 @@ variable "vmseries" {
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
     condition = alltrue([

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -1139,7 +1139,15 @@ The most basic properties are as follows:
   - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                 the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-  For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+- `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                      common properties are:
+
+  - `name` - (`string`, required) the Managed Disk name.
+  - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
 
 
 Type: 
@@ -1233,6 +1241,12 @@ map(object({
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
 ```
 

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -466,6 +466,8 @@ module "vmseries" {
     appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
+
   tags = var.tags
   depends_on = [
     module.vnet,

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -877,7 +877,15 @@ variable "vmseries" {
     - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                   the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-    For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+  - `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                        common properties are:
+
+    - `name` - (`string`, required) the Managed Disk name.
+    - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
   EOF
   default     = {}
   nullable    = false
@@ -969,6 +977,12 @@ variable "vmseries" {
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
     condition = alltrue([

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -1201,7 +1201,15 @@ The most basic properties are as follows:
   - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                 the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-  For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+- `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                      common properties are:
+
+  - `name` - (`string`, required) the Managed Disk name.
+  - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
 
 
 Type: 
@@ -1295,6 +1303,12 @@ map(object({
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
 ```
 

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -466,6 +466,8 @@ module "vmseries" {
     appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
+
   tags = var.tags
   depends_on = [
     module.vnet,

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -877,7 +877,15 @@ variable "vmseries" {
     - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                   the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-    For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+  - `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                        common properties are:
+
+    - `name` - (`string`, required) the Managed Disk name.
+    - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
   EOF
   default     = {}
   nullable    = false
@@ -969,6 +977,12 @@ variable "vmseries" {
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
     condition = alltrue([

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -1205,7 +1205,15 @@ The most basic properties are as follows:
   - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                 the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-  For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+- `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                      common properties are:
+
+  - `name` - (`string`, required) the Managed Disk name.
+  - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
 
 
 Type: 
@@ -1299,6 +1307,12 @@ map(object({
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
 ```
 

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -466,6 +466,8 @@ module "vmseries" {
     appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
+
   tags = var.tags
   depends_on = [
     module.vnet,

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -877,7 +877,15 @@ variable "vmseries" {
     - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                   the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-    For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+  - `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                        common properties are:
+
+    - `name` - (`string`, required) the Managed Disk name.
+    - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
   EOF
   default     = {}
   nullable    = false
@@ -969,6 +977,12 @@ variable "vmseries" {
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
     condition = alltrue([

--- a/examples/vmseries_transit_vnet_dedicated_vwan/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/README.md
@@ -1330,7 +1330,15 @@ The most basic properties are as follows:
   - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                 the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-  For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+- `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                      common properties are:
+
+  - `name` - (`string`, required) the Managed Disk name.
+  - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+  For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
 
 
 Type: 
@@ -1424,6 +1432,12 @@ map(object({
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
 ```
 

--- a/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
@@ -466,6 +466,8 @@ module "vmseries" {
     appgw_backend_pool_id        = try(v.appgw_backend_pool_id, null)
   }]
 
+  logging_disks = { for k, v in each.value.logging_disks : k => merge(v, { name = "${var.name_prefix}${v.name}" }) }
+
   tags = var.tags
   depends_on = [
     module.vnet,

--- a/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
@@ -989,7 +989,15 @@ variable "vmseries" {
     - `appgw_backend_pool_id`   - (`string`, optional, defaults to `null`) ID of the Application Gateway backend pool to which
                                   the network interface will be added. Mutually exclusive with `application_gateway_key`.
 
-    For details on all properties refer to [module's documentation](../../modules/panorama/README.md#interfaces).
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#interfaces).
+
+  - `logging_disks`   - (`map`, optional, defaults to `{}`) configuration of additional data disks for VM-Series logs. Most
+                        common properties are:
+
+    - `name` - (`string`, required) the Managed Disk name.
+    - `lun`  - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+
+    For details on all properties refer to [module's documentation](../../modules/vmseries/README.md#logging_disks).
   EOF
   default     = {}
   nullable    = false
@@ -1081,6 +1089,12 @@ variable "vmseries" {
       application_gateway_key = optional(string)
       appgw_backend_pool_id   = optional(string)
     }))
+    logging_disks = optional(map(object({
+      name      = string
+      size      = optional(string)
+      lun       = string
+      disk_type = optional(string)
+    })), {})
   }))
   validation { # virtual_machine.bootstrap_options & virtual_machine.bootstrap_package
     condition = alltrue([

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -324,15 +324,15 @@ Example:
 ```hcl
 {
   logs-1 = {
-    size: "2048"
-    zone: "1"
-    lun: "1"
+    name = "logs-disk1" 
+    size = "2048"
+    lun  = "1"
   }
   logs-2 = {
-    size: "2048"
-    zone: "2"
-    lun: "2"
-    disk_type: "StandardSSD_LRS"
+    name      = "logs-disk2"
+    size      = "2048"
+    lun       = "2"
+    disk_type = "StandardSSD_LRS"
   }
 }
 ```

--- a/modules/panorama/main.tf
+++ b/modules/panorama/main.tf
@@ -139,5 +139,5 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this" {
   managed_disk_id    = each.value.id
   virtual_machine_id = azurerm_linux_virtual_machine.this.id
   lun                = var.logging_disks[each.key].lun
-  caching            = "ReadWrite"
+  caching            = tonumber(var.logging_disks[each.key].size) > 4095 ? "None" : "ReadWrite"
 }

--- a/modules/panorama/variables.tf
+++ b/modules/panorama/variables.tf
@@ -253,7 +253,6 @@ variable "interfaces" {
   }
 }
 
-# Storage
 variable "logging_disks" {
   description = <<-EOF
    A map of objects describing the additional disks configuration.
@@ -272,15 +271,15 @@ variable "logging_disks" {
   ```hcl
   {
     logs-1 = {
-      size: "2048"
-      zone: "1"
-      lun: "1"
+      name = "logs-disk1" 
+      size = "2048"
+      lun  = "1"
     }
     logs-2 = {
-      size: "2048"
-      zone: "2"
-      lun: "2"
-      disk_type: "StandardSSD_LRS"
+      name      = "logs-disk2"
+      size      = "2048"
+      lun       = "2"
+      disk_type = "StandardSSD_LRS"
     }
   }
   ```

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -47,10 +47,12 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 ### Resources
 
 - `linux_virtual_machine` (managed)
+- `managed_disk` (managed)
 - `network_interface` (managed)
 - `network_interface_application_gateway_backend_address_pool_association` (managed)
 - `network_interface_backend_address_pool_association` (managed)
 - `public_ip` (managed)
+- `virtual_machine_data_disk_attachment` (managed)
 - `public_ip` (data)
 
 ### Required Inputs
@@ -70,6 +72,7 @@ Name | Type | Description
 Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | The map of tags to assign to all created resources.
+[`logging_disks`](#logging_disks) | `map` |  A map of objects describing the additional disks configuration.
 
 ### Outputs
 
@@ -389,6 +392,54 @@ list(object({
 The map of tags to assign to all created resources.
 
 Type: map(string)
+
+Default value: `map[]`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
+#### logging_disks
+
+ A map of objects describing the additional disks configuration.
+   
+Following configuration options are available:
+  
+- `name`      - (`string`, required) the Managed Disk name.
+- `size`      - (`string`, optional, defaults to "2048") size of the disk in GB. The recommended size for additional disks
+                is at least 2TB (2048 GB).
+- `lun`       - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+- `disk_type` - (`string`, optional, defaults to "StandardSSD_LRS") type of Managed Disk which should be created, possible
+                values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS` or `UltraSSD_LRS`.
+    
+Example:
+
+```hcl
+{
+  logs-1 = {
+    name = "logs-disk1"
+    size = "2048"
+    lun  = "1"
+  }
+  logs-2 = {
+    name      = "logs-disk2"
+    size      = "2048"
+    lun       = "2"
+    disk_type = "StandardSSD_LRS"
+  }
+}
+```
+
+
+Type: 
+
+```hcl
+map(object({
+    name      = string
+    size      = optional(string, "2048")
+    lun       = string
+    disk_type = optional(string, "StandardSSD_LRS")
+  }))
+```
+
 
 Default value: `map[]`
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -161,7 +161,6 @@ resource "azurerm_network_interface_backend_address_pool_association" "this" {
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_gateway_backend_address_pool_association
 resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "this" {
-
   for_each = { for v in var.interfaces : v.name => v.appgw_backend_pool_id if v.attach_to_appgw_backend_pool }
 
   network_interface_id    = azurerm_network_interface.this[each.key].id
@@ -172,4 +171,29 @@ resource "azurerm_network_interface_application_gateway_backend_address_pool_ass
     azurerm_network_interface.this,
     azurerm_linux_virtual_machine.this
   ]
+}
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_disk
+resource "azurerm_managed_disk" "this" {
+  for_each = var.logging_disks
+
+  name                          = each.value.name
+  location                      = var.region
+  resource_group_name           = var.resource_group_name
+  storage_account_type          = each.value.disk_type
+  create_option                 = "Empty"
+  disk_size_gb                  = each.value.size
+  zone                          = var.virtual_machine.zone != null && var.virtual_machine.zone != "" ? var.virtual_machine.zone : null
+  public_network_access_enabled = false
+  tags                          = var.tags
+}
+
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_data_disk_attachment
+resource "azurerm_virtual_machine_data_disk_attachment" "this" {
+  for_each = azurerm_managed_disk.this
+
+  managed_disk_id    = each.value.id
+  virtual_machine_id = azurerm_linux_virtual_machine.this.id
+  lun                = var.logging_disks[each.key].lun
+  caching            = "ReadWrite"
 }

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -195,5 +195,5 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this" {
   managed_disk_id    = each.value.id
   virtual_machine_id = azurerm_linux_virtual_machine.this.id
   lun                = var.logging_disks[each.key].lun
-  caching            = "ReadWrite"
+  caching            = tonumber(var.logging_disks[each.key].size) > 4095 ? "None" : "ReadWrite"
 }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -355,3 +355,66 @@ variable "interfaces" {
     EOF
   }
 }
+
+variable "logging_disks" {
+  description = <<-EOF
+   A map of objects describing the additional disks configuration.
+   
+  Following configuration options are available:
+  
+  - `name`      - (`string`, required) the Managed Disk name.
+  - `size`      - (`string`, optional, defaults to "2048") size of the disk in GB. The recommended size for additional disks
+                  is at least 2TB (2048 GB).
+  - `lun`       - (`string`, required) the Logical Unit Number of the Data Disk, which needs to be unique within the VM.
+  - `disk_type` - (`string`, optional, defaults to "StandardSSD_LRS") type of Managed Disk which should be created, possible
+                  values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS` or `UltraSSD_LRS`.
+    
+  Example:
+
+  ```hcl
+  {
+    logs-1 = {
+      name = "logs-disk1"
+      size = "2048"
+      lun  = "1"
+    }
+    logs-2 = {
+      name      = "logs-disk2"
+      size      = "2048"
+      lun       = "2"
+      disk_type = "StandardSSD_LRS"
+    }
+  }
+  ```
+  EOF
+  default     = {}
+  nullable    = false
+  type = map(object({
+    name      = string
+    size      = optional(string, "2048")
+    lun       = string
+    disk_type = optional(string, "StandardSSD_LRS")
+  }))
+  validation { # size
+    condition     = alltrue([for _, v in var.logging_disks : contains(range(2048, 24577, 2048), parseint(v.size, 10))])
+    error_message = <<-EOF
+    The `size` property value must be a multiple of `2048` but not higher than `24576` (24 TB).
+    EOF
+  }
+  validation { # lun
+    condition = alltrue([
+      for _, v in var.logging_disks : (parseint(v.lun, 10) >= 0 && parseint(v.lun, 10) <= 63) if v.lun != null
+    ])
+    error_message = <<-EOF
+    The `lun` property value must be a number between `0` and `63`.
+    EOF
+  }
+  validation { # disk_type
+    condition = alltrue([
+      for _, v in var.logging_disks : contains(["Standard_LRS", "StandardSSD_LRS", "Premium_LRS", "UltraSSD_LRS"], v.disk_type)
+    ])
+    error_message = <<-EOF
+    The `disk_type` property can be one of: `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS` or `UltraSSD_LRS`.
+    EOF
+  }
+}

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -396,9 +396,9 @@ variable "logging_disks" {
     disk_type = optional(string, "StandardSSD_LRS")
   }))
   validation { # size
-    condition     = alltrue([for _, v in var.logging_disks : contains(range(2048, 24577, 2048), parseint(v.size, 10))])
+    condition     = alltrue([for _, v in var.logging_disks : parseint(v.size, 10) >= 40 && parseint(v.size, 10) <= 8192])
     error_message = <<-EOF
-    The `size` property value must be a multiple of `2048` but not higher than `24576` (24 TB).
+    The `size` property value must be between `40` (40 GB) and `8192` (8 TB).
     EOF
   }
   validation { # lun


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces attaching additional data disks to VM-Series into the `vmseries` module, similarly to how it's done in the `panorama` module.

This enables extending VM-Series internal storage for logs.

Data disk size is limited from 40 GB to 8 TB according to the [documentation](https://docs.paloaltonetworks.com/vm-series/11-1/vm-series-deployment/set-up-the-vm-series-firewall-on-azure/about-the-vm-series-firewall-on-azure/minimum-system-requirements-for-the-vm-series-on-azure).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#180 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
