### PR TITLE
feat: Bump PAN-OS version to 11.2.8

### DIFF
--- a/examples/panorama_standalone/example.tfvars
+++ b/examples/panorama_standalone/example.tfvars
@@ -57,7 +57,7 @@ panoramas = {
       #ssh_keys                       = ["~/.ssh/id_rsa.pub"]
     }
     image = {
-      version = "11.1.607"
+      version = "11.2.8"
     }
     virtual_machine = {
       size      = "Standard_D5_v2"

--- a/examples/vmseries_gwlb/example.tfvars
+++ b/examples/vmseries_gwlb/example.tfvars
@@ -145,7 +145,7 @@ bootstrap_storages = {
 
 # All options under `vmseries_universal` map can be overwritten on a per-firewall basis under `vmseries` map
 vmseries_universal = {
-  version = "11.1.607"
+  version = "11.2.8"
   size    = "Standard_DS3_v2"
 
   # This example uses basic user-data bootstrap method by default, comment out the map below if you want to use another one

--- a/examples/vmseries_standalone/example.tfvars
+++ b/examples/vmseries_standalone/example.tfvars
@@ -75,7 +75,7 @@ vmseries = {
     name     = "firewall01"
     vnet_key = "transit"
     image = {
-      version = "11.1.607"
+      version = "11.2.8"
     }
     virtual_machine = {
       zone = null

--- a/examples/vmseries_transit_vnet_common/example.tfvars
+++ b/examples/vmseries_transit_vnet_common/example.tfvars
@@ -274,7 +274,7 @@ bootstrap_storages = {
 
 # All options under `vmseries_universal` map can be overwritten on a per-firewall basis under `vmseries` map
 vmseries_universal = {
-  version = "11.1.607"
+  version = "11.2.8"
   size    = "Standard_DS3_v2"
 
   # This example uses basic user-data bootstrap method by default, comment out the map below if you want to use another one

--- a/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_common_autoscale/example.tfvars
@@ -281,7 +281,7 @@ scale_sets = {
     name     = "common-vmss"
     vnet_key = "transit"
     image = {
-      version = "11.1.607"
+      version = "11.2.8"
     }
     authentication = {
       disable_password_authentication = false

--- a/examples/vmseries_transit_vnet_dedicated/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated/example.tfvars
@@ -206,7 +206,7 @@ bootstrap_storages = {
 
 # All options under `vmseries_universal` map can be overwritten on a per-firewall basis under `vmseries` map
 vmseries_universal = {
-  version = "11.1.607"
+  version = "11.2.8"
   size    = "Standard_DS3_v2"
 }
 

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/example.tfvars
@@ -221,7 +221,7 @@ bootstrap_storages = {
 
 # All options under `scale_sets_universal` map can be overwritten on a per-firewall basis under `scale_sets` map
 scale_sets_universal = {
-  version = "11.1.607"
+  version = "11.2.8"
   size    = "Standard_D3_v2"
 }
 

--- a/examples/vmseries_transit_vnet_dedicated_vwan/example.tfvars
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/example.tfvars
@@ -242,7 +242,7 @@ bootstrap_storages = {
 
 # All options under `vmseries_universal` map can be overwritten on a per-firewall basis under `vmseries` map
 vmseries_universal = {
-  version = "11.1.607"
+  version = "11.2.8"
   size    = "Standard_DS3_v2"
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR bumps PAN-OS version for VM-Series & Panorama to 11.2.8 in examples.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PAN-OS 11.2 is needed on Panorama to fully support Azure CloudNGFW.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
