### PR TITLE
fix(vmss): Fix sourcing PIP Prefix by name instead of ID

### DIFF
--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -118,11 +118,10 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
               name                    = "${nic.value.name}-${ip_configuration.value.name}-pip"
               domain_name_label       = ip_configuration.value.pip_domain_name_label
               idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
-              public_ip_prefix_id = try(
+              public_ip_prefix_id = try(coalesce(
                 ip_configuration.value.pip_prefix_id,
-                data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
-                null
-              )
+                try(data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id, null)
+              ), null)
             }
           }
         }
@@ -244,11 +243,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
               name                    = "${nic.value.name}-${ip_configuration.value.name}-pip"
               domain_name_label       = ip_configuration.value.pip_domain_name_label
               idle_timeout_in_minutes = ip_configuration.value.pip_idle_timeout_in_minutes
-              public_ip_prefix_id = try(
+              public_ip_prefix_id = try(coalesce(
                 ip_configuration.value.pip_prefix_id,
-                data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id,
-                null
-              )
+                try(data.azurerm_public_ip_prefix.allocate["${nic.value.name}-${ip_configuration.key}"].id, null)
+              ), null)
             }
           }
         }

--- a/modules/vmss/variables.tf
+++ b/modules/vmss/variables.tf
@@ -346,6 +346,17 @@ variable "interfaces" {
     The `pip_idle_timeout_in_minutes` value must be a number between 4 and 32.
     EOF
   }
+  validation { # pip_prefix_name & pip_prefix_id
+    condition = alltrue(flatten([
+      for interface in var.interfaces : [
+        for ip_config_name, ip_config in coalesce(interface.ip_configurations, {}) :
+        !(ip_config.pip_prefix_name != null && ip_config.pip_prefix_id != null)
+      ]
+    ]))
+    error_message = <<-EOF
+    The `pip_prefix_name` and `pip_prefix_id` properties are mutually exclusive, specify only one of them.
+    EOF
+  }
 }
 
 variable "autoscaling_configuration" {


### PR DESCRIPTION
## Description

This PR fixes sourcing Public IP Prefix by name and resource group in `vmss` module by changing the evaluation logic.

## Motivation and Context

#216 

## How Has This Been Tested?

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
