### PR TITLE
fix(vmseries): Fix the attachment of UltraSSD data disk

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -107,6 +107,13 @@ resource "azurerm_linux_virtual_machine" "this" {
     disk_encryption_set_id = var.virtual_machine.disk_encryption_set_id
   }
 
+  dynamic "additional_capabilities" {
+    for_each = anytrue([for _, v in var.logging_disks : v.disk_type == "UltraSSD_LRS"]) ? [1] : []
+    content {
+      ultra_ssd_enabled = true
+    }
+  }
+
   source_image_id = var.image.custom_id
 
   dynamic "source_image_reference" {
@@ -195,5 +202,8 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this" {
   managed_disk_id    = each.value.id
   virtual_machine_id = azurerm_linux_virtual_machine.this.id
   lun                = var.logging_disks[each.key].lun
-  caching            = tonumber(var.logging_disks[each.key].size) > 4095 ? "None" : "ReadWrite"
+  caching = (
+    var.logging_disks[each.key].disk_type == "UltraSSD_LRS" ||
+    tonumber(var.logging_disks[each.key].size) > 4095 ? "None" : "ReadWrite"
+  )
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Add `additional_capabilities` block enabling UltraSSD support on a VM in `vmseries` module.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The attachment of UltraSSD data disk was not possible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
