### PR TITLE
feat(natgw)!: Introduce NAT Gateway v2 and use it by default

### DIFF
--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -434,8 +434,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways.
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
 Following properties are supported:
@@ -449,11 +450,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -480,6 +484,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -125,6 +125,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways.
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -496,8 +496,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways.
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
 Following properties are supported:
@@ -511,11 +512,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -542,6 +546,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -125,6 +125,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways.
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_common_autoscale/.header.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/.header.md
@@ -58,7 +58,7 @@ This reference architecture consists of:
     - one dedicated to an Application Gateway
   - Route Tables and Network Security Groups
 - 1 Virtual Machine Scale Set:
-  - deployed across availability zones
+  - deployed across Availability Zones
   - for inbound, outbound and east-west traffic
   - with 3 network interfaces: management, public, private
   - with public IP addresses assigned to:

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -58,7 +58,7 @@ This reference architecture consists of:
     - one dedicated to an Application Gateway
   - Route Tables and Network Security Groups
 - 1 Virtual Machine Scale Set:
-  - deployed across availability zones
+  - deployed across Availability Zones
   - for inbound, outbound and east-west traffic
   - with 3 network interfaces: management, public, private
   - with public IP addresses assigned to:
@@ -529,8 +529,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways. 
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
   
 Following properties are supported:
@@ -544,11 +545,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -575,6 +579,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_common_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/main.tf
@@ -128,6 +128,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways. 
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
   
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -500,8 +500,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways.
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
 Following properties are supported:
@@ -515,11 +516,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -546,6 +550,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -125,6 +125,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways.
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -523,8 +523,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways. 
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
   
 Following properties are supported:
@@ -538,11 +539,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -569,6 +573,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
@@ -128,6 +128,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways. 
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
   
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated_vwan/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/README.md
@@ -505,8 +505,9 @@ Default value: `map[]`
 
 A map defining NAT Gateways.
 
-Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
 For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
 Following properties are supported:
@@ -520,11 +521,14 @@ Following properties are supported:
                           created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
 - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                           one).
+- `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                          `Standard` (zonal).
 - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                          Azure will pick a zone.
-- `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                          Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                          is `StandardV2`.
+- `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
 - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+- `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
 Example:
 ```
@@ -551,6 +555,7 @@ map(object({
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
@@ -125,6 +125,7 @@ module "natgw" {
   name                = each.value.create_natgw ? "${var.name_prefix}${each.value.name}" : each.value.name
   resource_group_name = coalesce(each.value.resource_group_name, local.resource_group.name)
   region              = var.region
+  sku_name            = each.value.sku_name
   zone                = try(each.value.zone, null)
   idle_timeout        = each.value.idle_timeout
   subnet_ids          = { for v in each.value.subnet_keys : v => module.vnet[each.value.vnet_key].subnet_ids[v] }

--- a/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
@@ -197,8 +197,9 @@ variable "natgws" {
   description = <<-EOF
   A map defining NAT Gateways.
 
-  Please note that a NAT Gateway is a zonal resource, this means it's always placed in a zone (even when you do not specify one
-  explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
+  Zone resiliency of a NAT Gateway depends on its SKU. The default `StandardV2` SKU is zone-redundant, Azure deploys it across
+  all Availability Zones in a region. The `Standard` SKU is a zonal resource, it is always placed in a single zone (even when
+  you do not specify one explicitly). Please refer to Microsoft documentation for notes on NAT Gateway's zonal resiliency.
   For detailed documentation on each property refer to [module documentation](../../modules/natgw/README.md).
 
   Following properties are supported:
@@ -212,11 +213,14 @@ variable "natgws" {
                             created or sourced: the NAT Gateway will be assigned to a subnet created by the `vnet` module.
   - `resource_group_name` - (`string`, optional) name of a Resource Group hosting the NAT Gateway (newly created or the existing
                             one).
+  - `sku_name`            - (`string`, optional) the SKU of a NAT Gateway, either `StandardV2` (zone-redundant) or
+                            `Standard` (zonal).
   - `zone`                - (`string`, optional) an Availability Zone in which the NAT Gateway will be placed, when skipped
-                            Azure will pick a zone.
-  - `idle_timeout`        - (`number`, optional, defults to 4) connection IDLE timeout in minutes, for newly created resources.
+                            Azure will pick a zone. Supported by the `Standard` SKU only, it has to stay unset when `sku_name`
+                            is `StandardV2`.
+  - `idle_timeout`        - (`number`, optional, defaults to 4) connection IDLE timeout in minutes, for newly created resources.
   - `public_ip`           - (`object`, optional) an object defining a public IP resource attached to the NAT Gateway.
-  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gatway.
+  - `public_ip_prefix`    - (`object`, optional) an object defining a public IP prefix resource attached to the NAT Gateway.
 
   Example:
   ```
@@ -240,6 +244,7 @@ variable "natgws" {
     subnet_keys         = list(string)
     create_natgw        = optional(bool, true)
     resource_group_name = optional(string)
+    sku_name            = optional(string)
     zone                = optional(string)
     idle_timeout        = optional(number, 4)
     public_ip = optional(object({

--- a/modules/natgw/.header.md
+++ b/modules/natgw/.header.md
@@ -10,10 +10,15 @@ This module can be used to either create a new NAT Gateway or to connect
 an existing one with subnets deployed using (for example) the [VNET
 module](../vnet/README.md).
 
-NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to
-decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. Keep in mind
-that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But
-if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+Zone resiliency depends on the SKU, controlled with the `sku_name` variable:
+
+- `StandardV2` (the module's default) is zone-redundant. Azure deploys it across all Availability Zones in a region on its own,
+  therefore the `zone` variable has to remain `null`. Any Public IP or Public IP Prefix created by this module is made
+  zone-redundant as well.
+- `Standard` is a zonal resource. It means that it's always deployed in a zone. It's up to the user to decide if a zone will be
+  specified during resource deployment or if Azure will take that decision for the user. Keep in mind that regardless of the
+  fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But if that zone becomes
+  unavailable, resources in other zones will lose internet connectivity.
 
 For design considerations, limitation and examples of zone-resiliency architecture please refer to
 [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
@@ -21,20 +26,16 @@ For design considerations, limitation and examples of zone-resiliency architectu
 ## Usage
 
 To deploy this resource in it's minimum configuration following code
-snippet can be used (assuming that the VNET module is used to deploy VNET
-and Subnets):
+snippet can be used:
 
 ```hcl
 module "natgw" {
   source = "PaloAltoNetworks/swfw-modules/azurerm//modules/natgw"
 
-  name                = "NATGW_name"
+  name                = "natgw_name"
   resource_group_name = "resource_group_name"
-  location            = "region_name"
+  region              = "region_name"
   subnet_ids          = { "subnet_name" = "/subscription/xxxx/......." }
   idle_timeout        = 120
 }
 ```
-
-This will create a NAT Gateway in with a single Public IP in a zone chosen
-by Azure.

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -9,10 +9,15 @@ This module can be used to either create a new NAT Gateway or to connect
 an existing one with subnets deployed using (for example) the [VNET
 module](../vnet/README.md).
 
-NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to
-decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. Keep in mind
-that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But
-if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+Zone resiliency depends on the SKU, controlled with the `sku_name` variable:
+
+- `StandardV2` (the module's default) is zone-redundant. Azure deploys it across all Availability Zones in a region on its own,
+  therefore the `zone` variable has to remain `null`. Any Public IP or Public IP Prefix created by this module is made
+  zone-redundant as well.
+- `Standard` is a zonal resource. It means that it's always deployed in a zone. It's up to the user to decide if a zone will be
+  specified during resource deployment or if Azure will take that decision for the user. Keep in mind that regardless of the
+  fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But if that zone becomes
+  unavailable, resources in other zones will lose internet connectivity.
 
 For design considerations, limitation and examples of zone-resiliency architecture please refer to
 [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
@@ -20,34 +25,30 @@ For design considerations, limitation and examples of zone-resiliency architectu
 ## Usage
 
 To deploy this resource in it's minimum configuration following code
-snippet can be used (assuming that the VNET module is used to deploy VNET
-and Subnets):
+snippet can be used:
 
 ```hcl
 module "natgw" {
   source = "PaloAltoNetworks/swfw-modules/azurerm//modules/natgw"
 
-  name                = "NATGW_name"
+  name                = "natgw_name"
   resource_group_name = "resource_group_name"
-  location            = "region_name"
+  region              = "region_name"
   subnet_ids          = { "subnet_name" = "/subscription/xxxx/......." }
   idle_timeout        = 120
 }
 ```
-
-This will create a NAT Gateway in with a single Public IP in a zone chosen
-by Azure.
 
 ## Reference
 
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 4.67
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 4.67
 
 
 
@@ -78,6 +79,7 @@ Name | Type | Description
 --- | --- | ---
 [`tags`](#tags) | `map` | A map of tags that will be assigned to resources created by this module.
 [`create_natgw`](#create_natgw) | `bool` | Triggers creation of a NAT Gateway when set to `true`.
+[`sku_name`](#sku_name) | `string` | The SKU of a NAT Gateway.
 [`zone`](#zone) | `string` | Controls whether the NAT Gateway will be bound to a specific zone or not.
 [`idle_timeout`](#idle_timeout) | `number` | Connection IDLE timeout in minutes (up to 120, defaults to Azure defaults).
 [`public_ip`](#public_ip) | `object` | A map defining a Public IP resource.
@@ -153,15 +155,39 @@ Default value: `true`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
+#### sku_name
+
+The SKU of a NAT Gateway. Only for newly created resources.
+
+Available values are `Standard` and `StandardV2`:
+
+- `Standard`   - a zonal resource, it is always deployed in a single zone, either the one specified with the `zone` variable
+                 or one picked by Azure. Any Public IP and Public IP Prefix created by this module follows the same zone.
+- `StandardV2` - a zone-redundant resource, Azure automatically deploys it across all Availability Zones in a region. The
+                 `zone` variable has to remain `null` and any Public IP and Public IP Prefix created by this module is
+                 zone-redundant as well.
+
+For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
+
+
+Type: string
+
+Default value: `StandardV2`
+
+<sup>[back to list](#modules-optional-inputs)</sup>
+
 #### zone
 
 Controls whether the NAT Gateway will be bound to a specific zone or not. This is a string with the zone number or `null`. Only
 for newly created resources.
 
-NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to
-decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. Keep in mind
-that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But
-if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+This variable applies to the `Standard` SKU only, which is a zonal resource. It means that it's always deployed in a zone.
+It's up to the user to decide if a zone will be specified during resource deployment or if Azure will take that decision for
+the user. Keep in mind that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for
+resources in all zones. But if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+
+A NAT Gateway of the `StandardV2` SKU is zone-redundant and is deployed by Azure across all Availability Zones in a region.
+Therefore this variable has to remain `null` when `sku_name` is set to `StandardV2`.
 
 For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
 

--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -1,3 +1,7 @@
+locals {
+  pip_zones = var.sku_name == "StandardV2" ? ["1", "2", "3"] : (var.zone != null ? [var.zone] : null)
+}
+
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip
 resource "azurerm_public_ip" "this" {
   count = try(var.create_natgw && var.public_ip.create, false) ? 1 : 0
@@ -7,7 +11,7 @@ resource "azurerm_public_ip" "this" {
   location            = var.region
   allocation_method   = "Static"
   sku                 = "Standard"
-  zones               = var.zone != null ? [var.zone] : null
+  zones               = local.pip_zones
 
   tags = var.tags
 }
@@ -30,7 +34,7 @@ resource "azurerm_public_ip_prefix" "this" {
   ip_version          = "IPv4"
   prefix_length       = var.public_ip_prefix.length
   sku                 = "Standard"
-  zones               = var.zone != null ? [var.zone] : null
+  zones               = local.pip_zones
 
   tags = var.tags
 }
@@ -50,11 +54,22 @@ resource "azurerm_nat_gateway" "this" {
   name                    = var.name
   resource_group_name     = var.resource_group_name
   location                = var.region
-  sku_name                = "Standard"
+  sku_name                = var.sku_name
   idle_timeout_in_minutes = var.idle_timeout
-  zones                   = var.zone != null ? [var.zone] : null
+  zones                   = var.sku_name == "StandardV2" ? null : (var.zone != null ? [var.zone] : null)
 
   tags = var.tags
+
+  lifecycle {
+    precondition { # sku_name & zone
+      condition     = var.sku_name == "StandardV2" ? var.zone == null : true
+      error_message = <<-EOF
+      NAT Gateway Name: [${var.name}]
+      A NAT Gateway of the "StandardV2" SKU is zone-redundant, Azure deploys it across all Availability Zones itself.
+      The `zone` variable has to be `null`. Use the "Standard" SKU to deploy a zonal NAT Gateway instead.
+      EOF
+    }
+  }
 }
 
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/nat_gateway

--- a/modules/natgw/variables.tf
+++ b/modules/natgw/variables.tf
@@ -39,15 +39,43 @@ variable "create_natgw" {
   type        = bool
 }
 
+variable "sku_name" {
+  description = <<-EOF
+  The SKU of a NAT Gateway. Only for newly created resources.
+
+  Available values are `Standard` and `StandardV2`:
+
+  - `Standard`   - a zonal resource, it is always deployed in a single zone, either the one specified with the `zone` variable
+                   or one picked by Azure. Any Public IP and Public IP Prefix created by this module follows the same zone.
+  - `StandardV2` - a zone-redundant resource, Azure automatically deploys it across all Availability Zones in a region. The
+                   `zone` variable has to remain `null` and any Public IP and Public IP Prefix created by this module is
+                   zone-redundant as well.
+
+  For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
+  EOF
+  default     = "StandardV2"
+  nullable    = false
+  type        = string
+  validation {
+    condition     = contains(["Standard", "StandardV2"], var.sku_name)
+    error_message = <<-EOF
+    The `sku_name` variable should have value of either: \"Standard\" or \"StandardV2\".
+    EOF
+  }
+}
+
 variable "zone" {
   description = <<-EOF
   Controls whether the NAT Gateway will be bound to a specific zone or not. This is a string with the zone number or `null`. Only
   for newly created resources.
 
-  NAT Gateway is not zone-redundant. It is a zonal resource. It means that it's always deployed in a zone. It's up to the user to
-  decide if a zone will be specified during resource deployment or if Azure will take that decision for the user. Keep in mind
-  that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for resources in all zones. But
-  if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+  This variable applies to the `Standard` SKU only, which is a zonal resource. It means that it's always deployed in a zone.
+  It's up to the user to decide if a zone will be specified during resource deployment or if Azure will take that decision for
+  the user. Keep in mind that regardless of the fact that NAT Gateway is placed in a specific zone it can serve traffic for
+  resources in all zones. But if that zone becomes unavailable, resources in other zones will lose internet connectivity.
+
+  A NAT Gateway of the `StandardV2` SKU is zone-redundant and is deployed by Azure across all Availability Zones in a region.
+  Therefore this variable has to remain `null` when `sku_name` is set to `StandardV2`.
 
   For design considerations, limitation and examples of zone-resiliency architecture please refer to [Microsoft documentation](https://learn.microsoft.com/en-us/azure/virtual-network/nat-gateway/nat-availability-zones).
   EOF
@@ -66,7 +94,7 @@ variable "idle_timeout" {
   default     = null
   type        = number
   validation {
-    condition     = (var.idle_timeout >= 1 && var.idle_timeout <= 120)
+    condition     = var.idle_timeout == null || (var.idle_timeout >= 1 && var.idle_timeout <= 120)
     error_message = <<-EOF
     The `idle_timeout` variable should be a number between 1 and 120.
     EOF

--- a/modules/natgw/versions.tf
+++ b/modules/natgw/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 4.67"
     }
   }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR introduces breaking changes to `natgw` module by upgrading it to `StandardV2` SKU, which makes the NAT Gateway zone-redundant. 

This is the new default module's behaviour. Legacy `Standard` SKU can still be used but variables need to be adjusted.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#191 
Zone-redundant NAT Gateway is much more useful in our Azure architectures.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
