### PR TITLE
feat!: Bump AzureRM to v5 and replace deprecated properties

### DIFF
--- a/examples/cloudngfw_centralized_single_vwan/README.md
+++ b/examples/cloudngfw_centralized_single_vwan/README.md
@@ -834,7 +834,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/cloudngfw_centralized_single_vwan/variables.tf
+++ b/examples/cloudngfw_centralized_single_vwan/variables.tf
@@ -618,7 +618,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/cloudngfw_centralized_vnet/README.md
+++ b/examples/cloudngfw_centralized_vnet/README.md
@@ -834,7 +834,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/cloudngfw_centralized_vnet/variables.tf
+++ b/examples/cloudngfw_centralized_vnet/variables.tf
@@ -618,7 +618,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/cloudngfw_distributed/README.md
+++ b/examples/cloudngfw_distributed/README.md
@@ -825,7 +825,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/cloudngfw_distributed/variables.tf
+++ b/examples/cloudngfw_distributed/variables.tf
@@ -618,7 +618,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_gwlb/README.md
+++ b/examples/vmseries_gwlb/README.md
@@ -1179,7 +1179,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_gwlb/variables.tf
+++ b/examples/vmseries_gwlb/variables.tf
@@ -957,7 +957,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -674,7 +674,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_standalone/README.md
+++ b/examples/vmseries_standalone/README.md
@@ -599,7 +599,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1473,7 +1473,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_standalone/main.tf
+++ b/examples/vmseries_standalone/main.tf
@@ -232,7 +232,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -354,7 +354,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1242,7 +1242,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_standalone/variables.tf
+++ b/examples/vmseries_standalone/variables.tf
@@ -422,7 +422,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -736,7 +736,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_common/README.md
+++ b/examples/vmseries_transit_vnet_common/README.md
@@ -661,7 +661,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1535,7 +1535,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_common/main.tf
+++ b/examples/vmseries_transit_vnet_common/main.tf
@@ -232,7 +232,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -354,7 +354,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1242,7 +1242,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_common/variables.tf
+++ b/examples/vmseries_transit_vnet_common/variables.tf
@@ -422,7 +422,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -694,7 +694,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1578,7 +1578,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_common_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_common_autoscale/README.md
@@ -769,7 +769,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/main.tf
@@ -219,7 +219,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -422,7 +422,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_common_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_common_autoscale/variables.tf
@@ -354,7 +354,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1221,7 +1221,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -665,7 +665,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1539,7 +1539,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated/README.md
+++ b/examples/vmseries_transit_vnet_dedicated/README.md
@@ -740,7 +740,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated/main.tf
@@ -232,7 +232,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -354,7 +354,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1242,7 +1242,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated/variables.tf
@@ -422,7 +422,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -763,7 +763,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/README.md
@@ -688,7 +688,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1572,7 +1572,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/main.tf
@@ -219,7 +219,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -422,7 +422,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_autoscale/variables.tf
@@ -354,7 +354,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1221,7 +1221,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated_vwan/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/README.md
@@ -790,7 +790,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1664,7 +1664,7 @@ map(object({
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated_vwan/README.md
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/README.md
@@ -865,7 +865,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/main.tf
@@ -232,7 +232,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
@@ -466,7 +466,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})
@@ -1354,7 +1354,7 @@ variable "test_infrastructure" {
           name                     = string
           protocol                 = string
           allocated_outbound_ports = optional(number)
-          enable_tcp_reset         = optional(bool)
+          tcp_reset_enabled        = optional(bool)
           idle_timeout_in_minutes  = optional(number)
         })), {})
       })), {})

--- a/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
+++ b/examples/vmseries_transit_vnet_dedicated_vwan/variables.tf
@@ -534,7 +534,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/modules/appgw/.header.md
+++ b/modules/appgw/.header.md
@@ -23,7 +23,7 @@ module "appgw" {
   managed_identities = each.value.managed_identities
   capacity           = each.value.capacity
   waf                = each.value.waf
-  enable_http2       = each.value.enable_http2
+  http2_enabled      = each.value.http2_enabled
   zones              = each.value.zones
 
   frontend_ip_configuration_name = each.value.frontend_ip_configuration_name

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -815,11 +815,11 @@ appgws = {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.62
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.62
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/appgw/README.md
+++ b/modules/appgw/README.md
@@ -23,7 +23,7 @@ module "appgw" {
   managed_identities = each.value.managed_identities
   capacity           = each.value.capacity
   waf                = each.value.waf
-  enable_http2       = each.value.enable_http2
+  http2_enabled      = each.value.http2_enabled
   zones              = each.value.zones
 
   frontend_ip_configuration_name = each.value.frontend_ip_configuration_name
@@ -850,7 +850,7 @@ Name | Type | Description
 [`zones`](#zones) | `list` | A list of zones the Application Gateway should be available in.
 [`domain_name_label`](#domain_name_label) | `string` | A label for the Domain Name.
 [`capacity`](#capacity) | `object` | A map defining whether static or autoscale configuration is used.
-[`enable_http2`](#enable_http2) | `bool` | Enable HTTP2 on the Application Gateway.
+[`http2_enabled`](#http2_enabled) | `bool` | Enable HTTP2 on the Application Gateway.
 [`waf`](#waf) | `object` | A map defining only the SKU and providing basic WAF (Web Application Firewall) configuration for Application Gateway.
 [`managed_identities`](#managed_identities) | `list` | A list of existing User-Assigned Managed Identities.
 [`global_ssl_policy`](#global_ssl_policy) | `object` | A map defining global SSL settings.
@@ -1096,7 +1096,7 @@ Default value: `map[]`
 
 <sup>[back to list](#modules-optional-inputs)</sup>
 
-#### enable_http2
+#### http2_enabled
 
 Enable HTTP2 on the Application Gateway.
 

--- a/modules/appgw/main.tf
+++ b/modules/appgw/main.tf
@@ -43,7 +43,7 @@ resource "azurerm_application_gateway" "this" {
   resource_group_name = var.resource_group_name
   location            = var.region
   zones               = var.zones
-  http2_enabled       = var.enable_http2
+  http2_enabled       = var.http2_enabled
   tags                = var.tags
 
   sku {

--- a/modules/appgw/variables.tf
+++ b/modules/appgw/variables.tf
@@ -131,7 +131,7 @@ variable "capacity" {
   }
 }
 
-variable "enable_http2" {
+variable "http2_enabled" {
   description = "Enable HTTP2 on the Application Gateway."
   default     = false
   type        = bool

--- a/modules/appgw/versions.tf
+++ b/modules/appgw/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.62"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -132,11 +132,11 @@ details refer to the [var.file_shares](#file_shares) variable documentation.
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.54
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.54
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -125,9 +125,9 @@ variable "storage_network_security" {
     allowed_subnet_ids = optional(list(string), [])
   })
   validation { # min_tls_version
-    condition     = contains(["TLS1_0", "TLS1_1", "TLS1_2"], var.storage_network_security.min_tls_version)
+    condition     = contains(["TLS1_2"], var.storage_network_security.min_tls_version)
     error_message = <<-EOF
-    The `min_tls_version` property can be one of: \"TLS1_0\", \"TLS1_1\", \"TLS1_2\".
+    The `min_tls_version` property can be one of: \"TLS1_2\".
     EOF
   }
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.54"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/cloudngfw/README.md
+++ b/modules/cloudngfw/README.md
@@ -147,11 +147,11 @@ cloudngfws = {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.19
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.19
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/cloudngfw/README.md
+++ b/modules/cloudngfw/README.md
@@ -249,10 +249,9 @@ Map of objects describing Palo Alto Next Generation Firewalls (cloudngfw).
 
 List of available properties:
 
-- `plan_id`                         - (`string`, optional, defaults to `panw-cngfw-payg`) the former plan_id
-                                      `panw-cloud-ngfw-payg` is defined as stop sell, but has been set as the provider default
-                                      to not break any existing resources that were originally provisioned with it. Users need
-                                      to explicitly set the `plan_id` to `panw-cngfw-payg` when creating new resources.
+- `plan_id`                         - (`string`, optional, defaults to `panw-cngfw-payg`) the former provider-default plan_id
+                                      `panw-cloud-ngfw-payg` is defined as stop sell, users need to explicitly set it for 
+                                      backwards compatibility. New plan_id `panw-cngfw-payg` is the default from provider v5.
 - `marketplace_offer_id`            - (`string`, optional, defaults to `pan_swfw_cloud_ngfw`) the marketplace offer ID,
                                       changing this forces a new resource to be created.
 - `rulestack_id`                    - (`string`, optional) the ID of the Local Rulestack used to configure this Firewall

--- a/modules/cloudngfw/variables.tf
+++ b/modules/cloudngfw/variables.tf
@@ -92,10 +92,9 @@ variable "cloudngfw_config" {
 
   List of available properties:
 
-  - `plan_id`                         - (`string`, optional, defaults to `panw-cngfw-payg`) the former plan_id
-                                        `panw-cloud-ngfw-payg` is defined as stop sell, but has been set as the provider default
-                                        to not break any existing resources that were originally provisioned with it. Users need
-                                        to explicitly set the `plan_id` to `panw-cngfw-payg` when creating new resources.
+  - `plan_id`                         - (`string`, optional, defaults to `panw-cngfw-payg`) the former provider-default plan_id
+                                        `panw-cloud-ngfw-payg` is defined as stop sell, users need to explicitly set it for 
+                                        backwards compatibility. New plan_id `panw-cngfw-payg` is the default from provider v5.
   - `marketplace_offer_id`            - (`string`, optional, defaults to `pan_swfw_cloud_ngfw`) the marketplace offer ID,
                                         changing this forces a new resource to be created.
   - `rulestack_id`                    - (`string`, optional) the ID of the Local Rulestack used to configure this Firewall

--- a/modules/cloudngfw/versions.tf
+++ b/modules/cloudngfw/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.19"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/gwlb/README.md
+++ b/modules/gwlb/README.md
@@ -89,11 +89,11 @@ For more customized requirements, below extended definition of GWLB can be appli
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/gwlb/versions.tf
+++ b/modules/gwlb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -245,7 +245,7 @@ switches the outgoing traffic route for **ALL** `in_rules`.
                                 when skipped provider defaults will be used (`1024`),
                                 when set to `0` port allocation will be set to default number (Azure defaults);
                                 maximum value is `64000`.
-- `enable_tcp_reset`          - (`bool`, optional, defaults to Azure defaults) ignored when `protocol` is set to `Udp`.
+- `tcp_reset_enabled`         - (`bool`, optional, defaults to Azure defaults) ignored when `protocol` is set to `Udp`.
 - `idle_timeout_in_minutes`   - (`number`, optional, defaults to Azure defaults) TCP connection timeout in minutes (between 4 
                                 and 120) in case the connection is idle, ignored when `protocol` is set to `Udp`.
 
@@ -298,7 +298,7 @@ frontend_ips = {
     "outbound_tcp" = {
       protocol                 = "Tcp"
       allocated_outbound_ports = 2048
-      enable_tcp_reset         = true
+      tcp_reset_enabled         = true
       idle_timeout_in_minutes  = 10
     }
   }
@@ -336,7 +336,7 @@ map(object({
       name                     = string
       protocol                 = string
       allocated_outbound_ports = optional(number)
-      enable_tcp_reset         = optional(bool)
+      tcp_reset_enabled        = optional(bool)
       idle_timeout_in_minutes  = optional(number)
     })), {})
   }))

--- a/modules/loadbalancer/README.md
+++ b/modules/loadbalancer/README.md
@@ -89,11 +89,11 @@ module "lbe" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.42
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.42
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -180,7 +180,7 @@ resource "azurerm_lb_outbound_rule" "this" {
   backend_address_pool_id = azurerm_lb_backend_address_pool.this.id
 
   protocol                 = each.value.rule.protocol
-  tcp_reset_enabled        = each.value.rule.protocol != "Udp" ? each.value.rule.enable_tcp_reset : null
+  tcp_reset_enabled        = each.value.rule.protocol != "Udp" ? each.value.rule.tcp_reset_enabled : null
   allocated_outbound_ports = each.value.rule.allocated_outbound_ports
   idle_timeout_in_minutes  = each.value.rule.protocol != "Udp" ? each.value.rule.idle_timeout_in_minutes : null
 

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -124,7 +124,7 @@ variable "frontend_ips" {
                                   when skipped provider defaults will be used (`1024`),
                                   when set to `0` port allocation will be set to default number (Azure defaults);
                                   maximum value is `64000`.
-  - `enable_tcp_reset`          - (`bool`, optional, defaults to Azure defaults) ignored when `protocol` is set to `Udp`.
+  - `tcp_reset_enabled`         - (`bool`, optional, defaults to Azure defaults) ignored when `protocol` is set to `Udp`.
   - `idle_timeout_in_minutes`   - (`number`, optional, defaults to Azure defaults) TCP connection timeout in minutes (between 4 
                                   and 120) in case the connection is idle, ignored when `protocol` is set to `Udp`.
 
@@ -177,7 +177,7 @@ variable "frontend_ips" {
       "outbound_tcp" = {
         protocol                 = "Tcp"
         allocated_outbound_ports = 2048
-        enable_tcp_reset         = true
+        tcp_reset_enabled         = true
         idle_timeout_in_minutes  = 10
       }
     }
@@ -211,7 +211,7 @@ variable "frontend_ips" {
       name                     = string
       protocol                 = string
       allocated_outbound_ports = optional(number)
-      enable_tcp_reset         = optional(bool)
+      tcp_reset_enabled        = optional(bool)
       idle_timeout_in_minutes  = optional(number)
     })), {})
   }))

--- a/modules/loadbalancer/versions.tf
+++ b/modules/loadbalancer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.42"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/natgw/README.md
+++ b/modules/natgw/README.md
@@ -44,11 +44,11 @@ module "natgw" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.67
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.67
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/natgw/versions.tf
+++ b/modules/natgw/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.67"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/ngfw_metrics/README.md
+++ b/modules/ngfw_metrics/README.md
@@ -59,11 +59,11 @@ module "ngfw_metrics" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/ngfw_metrics/versions.tf
+++ b/modules/ngfw_metrics/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -22,11 +22,11 @@ The acceptance applies to the entirety of your Azure Subscription.
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/panorama/versions.tf
+++ b/modules/panorama/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/public_ip/README.md
+++ b/modules/public_ip/README.md
@@ -125,11 +125,11 @@ variable "public_ips" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/public_ip/versions.tf
+++ b/modules/public_ip/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/route_server/README.md
+++ b/modules/route_server/README.md
@@ -88,11 +88,11 @@ variable "route_servers" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/route_server/versions.tf
+++ b/modules/route_server/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -13,11 +13,11 @@ For usage please refer to any reference architecture example.
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Modules
 Name | Version | Source | Description

--- a/modules/test_infrastructure/.README.md
+++ b/modules/test_infrastructure/.README.md
@@ -425,7 +425,7 @@ map(object({
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})

--- a/modules/test_infrastructure/variables.tf
+++ b/modules/test_infrastructure/variables.tf
@@ -214,7 +214,7 @@ variable "load_balancers" {
         name                     = string
         protocol                 = string
         allocated_outbound_ports = optional(number)
-        enable_tcp_reset         = optional(bool)
+        tcp_reset_enabled        = optional(bool)
         idle_timeout_in_minutes  = optional(number)
       })), {})
     })), {})

--- a/modules/test_infrastructure/versions.tf
+++ b/modules/test_infrastructure/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -304,11 +304,11 @@ variable "virtual_network_gateways" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.62
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.62
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -657,8 +657,8 @@ Every object in the map contains following attributes:
   - `bgp_peering_address` - (`string`, required) the BGP peering address and BGP identifier of this BGP speaker.
   - `peer_weight`         - (`number`, optional, defaults to `null`) the weight added to routes learned from this BGP speaker.
 - `gateway_address`      - (`string`, optional, defaults to `null`) the gateway IP address to connect with.
-- `address_space`        - (`list`, optional, defaults to `[]`) the list of string CIDRs representing the address spaces
-                           the gateway exposes.
+- `address_space`        - (`set`, optional, defaults to `[]`) the list of string CIDRs representing the address spaces the
+                           gateway exposes.
 - `custom_bgp_addresses` - (`list`, optional, defaults to `[]`) Border Gateway Protocol custom IP Addresses,
                            which can only be used on IPSec / active-active connections. Object contains 2 attributes:
   - `primary_key`   - (`string`, required) single IP address that is part of the azurerm_virtual_network_gateway
@@ -697,7 +697,7 @@ map(object({
       bgp_peering_address = string
       peer_weight         = optional(number)
     }))
-    address_space   = optional(list(string), [])
+    address_space   = optional(set(string), [])
     gateway_address = optional(string)
     connection = object({
       name = string

--- a/modules/virtual_network_gateway/variables.tf
+++ b/modules/virtual_network_gateway/variables.tf
@@ -363,8 +363,8 @@ variable "local_network_gateways" {
     - `bgp_peering_address` - (`string`, required) the BGP peering address and BGP identifier of this BGP speaker.
     - `peer_weight`         - (`number`, optional, defaults to `null`) the weight added to routes learned from this BGP speaker.
   - `gateway_address`      - (`string`, optional, defaults to `null`) the gateway IP address to connect with.
-  - `address_space`        - (`list`, optional, defaults to `[]`) the list of string CIDRs representing the address spaces
-                             the gateway exposes.
+  - `address_space`        - (`set`, optional, defaults to `[]`) the list of string CIDRs representing the address spaces the
+                             gateway exposes.
   - `custom_bgp_addresses` - (`list`, optional, defaults to `[]`) Border Gateway Protocol custom IP Addresses,
                              which can only be used on IPSec / active-active connections. Object contains 2 attributes:
     - `primary_key`   - (`string`, required) single IP address that is part of the azurerm_virtual_network_gateway
@@ -401,7 +401,7 @@ variable "local_network_gateways" {
       bgp_peering_address = string
       peer_weight         = optional(number)
     }))
-    address_space   = optional(list(string), [])
+    address_space   = optional(set(string), [])
     gateway_address = optional(string)
     connection = object({
       name = string

--- a/modules/virtual_network_gateway/versions.tf
+++ b/modules/virtual_network_gateway/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.62"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -36,11 +36,11 @@ If your Region doesn't, use an alternative mechanism of Availability Set, which 
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vmss/README.md
+++ b/modules/vmss/README.md
@@ -120,11 +120,11 @@ module "vmss" {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Modules
 Name | Version | Source | Description

--- a/modules/vmss/main.tf
+++ b/modules/vmss/main.tf
@@ -114,10 +114,10 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "this" {
     iterator = nic
 
     content {
-      name                          = nic.value.name
-      primary                       = nic.key == 0 ? true : false
-      enable_ip_forwarding          = nic.key == 0 ? false : true
-      enable_accelerated_networking = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
+      name                           = nic.value.name
+      primary                        = nic.key == 0 ? true : false
+      ip_forwarding_enabled          = nic.key == 0 ? false : true
+      accelerated_networking_enabled = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
 
       dynamic "ip_configuration" {
         for_each = nic.value.ip_configurations
@@ -260,10 +260,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "this" {
     iterator = nic
 
     content {
-      name                          = nic.value.name
-      primary                       = nic.key == 0 ? true : false
-      enable_ip_forwarding          = nic.key == 0 ? false : true
-      enable_accelerated_networking = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
+      name                           = nic.value.name
+      primary                        = nic.key == 0 ? true : false
+      ip_forwarding_enabled          = nic.key == 0 ? false : true
+      accelerated_networking_enabled = nic.key == 0 ? false : var.virtual_machine_scale_set.accelerated_networking
 
       dynamic "ip_configuration" {
         for_each = nic.value.ip_configurations

--- a/modules/vmss/versions.tf
+++ b/modules/vmss/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vnet/README.md
+++ b/modules/vnet/README.md
@@ -139,11 +139,11 @@ This module is designed to work in several *modes* depending on which variables 
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/vnet/main.tf
+++ b/modules/vnet/main.tf
@@ -53,9 +53,15 @@ resource "azurerm_subnet" "this" {
   virtual_network_name                          = local.virtual_network.name
   address_prefixes                              = each.value.address_prefixes
   default_outbound_access_enabled               = each.value.default_outbound_access_enabled
-  service_endpoints                             = each.value.enable_storage_service_endpoint ? ["Microsoft.Storage"] : null
   private_endpoint_network_policies             = each.value.private_endpoint_network_policies
   private_link_service_network_policies_enabled = each.value.enable_private_link_network_policies
+
+  dynamic "service_endpoint" {
+    for_each = each.value.enable_storage_service_endpoint ? [1] : []
+    content {
+      service = "Microsoft.Storage"
+    }
+  }
 
   dynamic "delegation" {
     for_each = each.value.enable_appgw_delegation ? [1] : []

--- a/modules/vnet/versions.tf
+++ b/modules/vnet/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vnet_peering/README.md
+++ b/modules/vnet_peering/README.md
@@ -25,11 +25,11 @@ remote_peer_config = {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/vnet_peering/versions.tf
+++ b/modules/vnet_peering/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vwan/README.md
+++ b/modules/vwan/README.md
@@ -173,11 +173,11 @@ virtual_wans = {
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/vwan/versions.tf
+++ b/modules/vwan/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/vwan_routes/README.md
+++ b/modules/vwan_routes/README.md
@@ -133,11 +133,11 @@ Below there are provided sample values:
 ### Requirements
 
 - `terraform`, version: >= 1.5, < 2.0
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 ### Providers
 
-- `azurerm`, version: ~> 4.0
+- `azurerm`, version: ~> 5.0
 
 
 

--- a/modules/vwan_routes/versions.tf
+++ b/modules/vwan_routes/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/tests/appgw/README.md
+++ b/tests/appgw/README.md
@@ -228,7 +228,7 @@ map(object({
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/tests/appgw/example.tfvars
+++ b/tests/appgw/example.tfvars
@@ -214,7 +214,7 @@ appgws = {
     capacity = {
       static = 4
     }
-    enable_http2 = true
+    http2_enabled = true
     waf = {
       prevention_mode  = true
       rule_set_type    = "OWASP"

--- a/tests/appgw/main.tf
+++ b/tests/appgw/main.tf
@@ -104,7 +104,7 @@ module "appgw" {
   )
   domain_name_label              = each.value.domain_name_label
   capacity                       = each.value.capacity
-  enable_http2                   = each.value.enable_http2
+  http2_enabled                  = each.value.http2_enabled
   waf                            = each.value.waf
   managed_identities             = each.value.managed_identities
   global_ssl_policy              = each.value.global_ssl_policy

--- a/tests/appgw/variables.tf
+++ b/tests/appgw/variables.tf
@@ -233,7 +233,7 @@ variable "appgws" {
         max = number
       }))
     }))
-    enable_http2 = optional(bool)
+    http2_enabled = optional(bool)
     waf = optional(object({
       prevention_mode  = bool
       rule_set_type    = optional(string)

--- a/tests/virtual_network_gateway/README.md
+++ b/tests/virtual_network_gateway/README.md
@@ -325,7 +325,7 @@ map(object({
         peer_weight         = optional(number)
       }))
       gateway_address = optional(string)
-      address_space   = optional(list(string), [])
+      address_space   = optional(set(string), [])
       connection = object({
         name = string
         custom_bgp_addresses = optional(object({

--- a/tests/virtual_network_gateway/variables.tf
+++ b/tests/virtual_network_gateway/variables.tf
@@ -237,7 +237,7 @@ variable "virtual_network_gateways" {
         peer_weight         = optional(number)
       }))
       gateway_address = optional(string)
-      address_space   = optional(list(string), [])
+      address_space   = optional(set(string), [])
       connection = object({
         name = string
         custom_bgp_addresses = optional(object({


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR replaces deprecated properties which stop working in AzureRM provider v5. It also bumps the minimum provider version to v5.0 in modules version constraints.

Change is breaking because in some cases, variable name got changed too.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Old properties stop working in v5 of the AzureRM provider.
[AzureRM v5 upgrade guide](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/5.0-upgrade-guide)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
