### PR TITLE
fix(natgw): Control PIP and PIP Prefix SKU with a variable in NATGW module

### DIFF
--- a/modules/natgw/main.tf
+++ b/modules/natgw/main.tf
@@ -10,7 +10,7 @@ resource "azurerm_public_ip" "this" {
   resource_group_name = var.resource_group_name
   location            = var.region
   allocation_method   = "Static"
-  sku                 = "Standard"
+  sku                 = var.sku_name
   zones               = local.pip_zones
 
   tags = var.tags
@@ -33,7 +33,7 @@ resource "azurerm_public_ip_prefix" "this" {
   location            = var.region
   ip_version          = "IPv4"
   prefix_length       = var.public_ip_prefix.length
-  sku                 = "Standard"
+  sku                 = var.sku_name
   zones               = local.pip_zones
 
   tags = var.tags


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

This PR controls the NAT Gateway module `natgw` Public IP and Public IP Prefix SKU with a `sku_name` variable.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Public IP and Public IP Prefix used in `StandardV2` NAT Gateway also need to be of `StandardV2` SKU.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Deployed locally.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
